### PR TITLE
fix(mobile): improve responsiveness across all admin pages

### DIFF
--- a/src/app/admin/cashier/page.tsx
+++ b/src/app/admin/cashier/page.tsx
@@ -227,7 +227,7 @@ export default function Cashier() {
             <div className="grid gap-4 py-4">
               <editForm.Field name="description">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="edit-desc">Description</Label>
                     <div className="col-span-3">
                       <Input id="edit-desc" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} error={field.state.meta.errors.length > 0 ? field.state.meta.errors.map(e => e?.message ?? e).join(", ") : undefined} />
@@ -237,7 +237,7 @@ export default function Cashier() {
               </editForm.Field>
               <editForm.Field name="category">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="edit-cat">Category</Label>
                     <Input id="edit-cat" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} className="col-span-3" />
                   </div>
@@ -245,7 +245,7 @@ export default function Cashier() {
               </editForm.Field>
               <editForm.Field name="type">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="edit-type">Type</Label>
                     <Select value={field.state.value} onValueChange={(v) => field.handleChange(v as TransactionType)}>
                       <SelectTrigger id="edit-type" className="col-span-3"><SelectValue /></SelectTrigger>
@@ -256,7 +256,7 @@ export default function Cashier() {
               </editForm.Field>
               <editForm.Field name="amount">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="edit-amount">Amount</Label>
                     <div className="col-span-3">
                       <Input id="edit-amount" type="number" min="0.01" step="0.01" value={field.state.value} onChange={(e) => field.handleChange(Number(e.target.value))} onBlur={field.handleBlur} error={field.state.meta.errors.length > 0 ? field.state.meta.errors.map(e => e?.message ?? e).join(", ") : undefined} />
@@ -266,7 +266,7 @@ export default function Cashier() {
               </editForm.Field>
               <editForm.Field name="status">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="edit-status">Status</Label>
                     <Select value={field.state.value} onValueChange={(v) => field.handleChange(v as TransactionStatus)}>
                       <SelectTrigger id="edit-status" className="col-span-3"><SelectValue /></SelectTrigger>

--- a/src/app/admin/customers/page.tsx
+++ b/src/app/admin/customers/page.tsx
@@ -169,7 +169,7 @@ export default function CustomersPage() {
   if (error) { return <Card><CardContent><p className="text-red-500">{error.message}</p></CardContent></Card>; }
 
   return (
-    <Card className="flex flex-col gap-6 p-6">
+    <Card className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
       <CardHeader className="p-0">
         <SearchFilter
           search={searchTerm}
@@ -205,7 +205,7 @@ export default function CustomersPage() {
             <div className="grid gap-4 py-4">
               <form.Field name="name">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="name">Name</Label>
                     <div className="col-span-3">
                       <Input id="name" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} error={field.state.meta.errors.length > 0 ? field.state.meta.errors.map(e => e?.message ?? e).join(", ") : undefined} />
@@ -215,7 +215,7 @@ export default function CustomersPage() {
               </form.Field>
               <form.Field name="email">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="email">Email</Label>
                     <div className="col-span-3">
                       <Input id="email" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} error={field.state.meta.errors.length > 0 ? field.state.meta.errors.map(e => e?.message ?? e).join(", ") : undefined} />
@@ -225,7 +225,7 @@ export default function CustomersPage() {
               </form.Field>
               <form.Field name="phone">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="phone">Phone</Label>
                     <Input id="phone" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} className="col-span-3" />
                   </div>
@@ -233,7 +233,7 @@ export default function CustomersPage() {
               </form.Field>
               <form.Field name="status">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="status">Status</Label>
                     <Select value={field.state.value} onValueChange={(value) => field.handleChange(value as "active" | "inactive")}>
                       <SelectTrigger id="status" className="col-span-3"><SelectValue placeholder="Select status" /></SelectTrigger>

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -175,7 +175,7 @@ export default function OrdersPage() {
   if (error) { return <Card><CardContent><p className="text-red-500">{error.message}</p></CardContent></Card>; }
 
   return (
-    <Card className="flex flex-col gap-6 p-6">
+    <Card className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
       <CardHeader className="p-0">
         <SearchFilter
           search={searchTerm}
@@ -207,13 +207,13 @@ export default function OrdersPage() {
             }}
           >
             <div className="grid gap-4 py-4">
-              <div className="grid grid-cols-4 items-center gap-4">
+              <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                 <Label htmlFor="customerName">Customer</Label>
                 <Input id="customerName" value={editCustomerName} disabled className="col-span-3" />
               </div>
               <form.Field name="total">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="total">Total</Label>
                     <div className="col-span-3">
                       <Input id="total" type="number" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} error={field.state.meta.errors.length > 0 ? field.state.meta.errors.map(e => e?.message ?? e).join(", ") : undefined} />
@@ -223,7 +223,7 @@ export default function OrdersPage() {
               </form.Field>
               <form.Field name="status">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="status">Status</Label>
                     <Select value={field.state.value} onValueChange={(value) => field.handleChange(value as OrderStatus)}>
                       <SelectTrigger id="status" className="col-span-3"><SelectValue placeholder="Select status" /></SelectTrigger>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -88,7 +88,7 @@ export default function Page() {
   const profitIsPositive = data.totalProfit >= 0;
 
   return (
-    <div className="grid flex-1 items-start gap-6">
+    <div className="grid flex-1 items-start gap-6 min-w-0 overflow-hidden">
       {/* KPI Cards */}
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <Card>
@@ -146,7 +146,7 @@ export default function Page() {
       </div>
 
       {/* Charts Grid */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid gap-6 lg:grid-cols-2 min-w-0">
         <CategoryPieChart
           title="Revenue by Category"
           description="Breakdown of income across categories"
@@ -196,7 +196,7 @@ function CategoryPieChart({
   );
 
   return (
-    <Card>
+    <Card className="min-w-0 overflow-hidden">
       <CardHeader className="pb-2">
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
@@ -278,7 +278,7 @@ function ProfitMarginChart({
   } satisfies ChartConfig;
 
   return (
-    <Card>
+    <Card className="min-w-0 overflow-hidden">
       <CardHeader className="pb-2">
         <CardTitle>Profit Margin</CardTitle>
         <CardDescription>Daily profit margin percentage</CardDescription>
@@ -344,7 +344,7 @@ function CashFlowChart({
   } satisfies ChartConfig;
 
   return (
-    <Card>
+    <Card className="min-w-0 overflow-hidden">
       <CardHeader className="pb-2">
         <CardTitle>Cash Flow</CardTitle>
         <CardDescription>Daily transaction volume</CardDescription>

--- a/src/app/admin/payment-methods/page.tsx
+++ b/src/app/admin/payment-methods/page.tsx
@@ -121,7 +121,7 @@ export default function PaymentMethodsPage() {
   if (error) { return <Card><CardContent><p className="text-red-500">{error.message}</p></CardContent></Card>; }
 
   return (
-    <Card className="flex flex-col gap-6 p-6">
+    <Card className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
       <CardHeader className="p-0">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 text-muted-foreground">
@@ -154,7 +154,7 @@ export default function PaymentMethodsPage() {
             <div className="grid gap-4 py-4">
               <form.Field name="name">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
                     <Label htmlFor="method-name">Name</Label>
                     <div className="col-span-3">
                       <Input

--- a/src/app/admin/pos/page.tsx
+++ b/src/app/admin/pos/page.tsx
@@ -161,12 +161,12 @@ export default function POSPage() {
   }
 
   return (
-    <div className="container mx-auto p-4">
+    <div className="w-full max-w-4xl mx-auto">
       <Card className="mb-4">
         <CardHeader>
           <CardTitle>Sale Details</CardTitle>
         </CardHeader>
-        <CardContent className="flex gap-4">
+        <CardContent className="flex flex-col sm:flex-row gap-3 sm:gap-4">
           <div className="flex-1">
             <Combobox
               items={customers}
@@ -186,12 +186,12 @@ export default function POSPage() {
       <Card>
         <CardHeader>
           <CardTitle>Products</CardTitle>
-          <div className="flex gap-3 !mt-4">
+          <div className="flex flex-col sm:flex-row gap-3 !mt-4">
             <div className="relative flex-1">
               <SearchIcon className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
                 type="text"
-                placeholder="Search products by name or category..."
+                placeholder="Search products..."
                 value={productSearch}
                 onChange={(e) => setProductSearch(e.target.value)}
                 className="pl-8"
@@ -214,77 +214,81 @@ export default function POSPage() {
               Select products above to add them to the order
             </div>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Product</TableHead>
-                  <TableHead>Price</TableHead>
-                  <TableHead>Stock</TableHead>
-                  <TableHead>Quantity</TableHead>
-                  <TableHead>Total</TableHead>
-                  <TableHead>Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {selectedProducts.map((product) => {
-                  const source = products.find((p) => p.id === product.id);
-                  return (
-                    <TableRow key={product.id}>
-                      <TableCell className="font-medium">{product.name}</TableCell>
-                      <TableCell>${(product.price / 100).toFixed(2)}</TableCell>
-                      <TableCell>
-                        <Badge variant={source && source.in_stock > 5 ? "default" : "destructive"}>
-                          {source?.in_stock ?? 0}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-1">
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Product</TableHead>
+                    <TableHead className="hidden sm:table-cell">Price</TableHead>
+                    <TableHead className="hidden md:table-cell">Stock</TableHead>
+                    <TableHead>Qty</TableHead>
+                    <TableHead>Total</TableHead>
+                    <TableHead className="w-10"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {selectedProducts.map((product) => {
+                    const source = products.find((p) => p.id === product.id);
+                    return (
+                      <TableRow key={product.id}>
+                        <TableCell className="font-medium">{product.name}</TableCell>
+                        <TableCell className="hidden sm:table-cell">${(product.price / 100).toFixed(2)}</TableCell>
+                        <TableCell className="hidden md:table-cell">
+                          <Badge variant={source && source.in_stock > 5 ? "default" : "destructive"}>
+                            {source?.in_stock ?? 0}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              className="h-7 w-7"
+                              onClick={() => handleQuantityChange(product.id, -1)}
+                              disabled={product.quantity <= 1}
+                            >
+                              <MinusIcon className="h-3 w-3" />
+                            </Button>
+                            <span className="w-8 text-center tabular-nums">{product.quantity}</span>
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              className="h-7 w-7"
+                              onClick={() => handleQuantityChange(product.id, 1)}
+                              disabled={source ? product.quantity >= source.in_stock : false}
+                            >
+                              <PlusIcon className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          ${(product.quantity * product.price / 100).toFixed(2)}
+                        </TableCell>
+                        <TableCell>
                           <Button
+                            variant="ghost"
                             size="icon"
-                            variant="outline"
-                            className="h-7 w-7"
-                            onClick={() => handleQuantityChange(product.id, -1)}
-                            disabled={product.quantity <= 1}
+                            className="h-8 w-8"
+                            onClick={() => handleRemoveProduct(product.id)}
                           >
-                            <MinusIcon className="h-3 w-3" />
+                            <Trash2Icon className="h-4 w-4" />
+                            <span className="sr-only">Remove</span>
                           </Button>
-                          <span className="w-8 text-center tabular-nums">{product.quantity}</span>
-                          <Button
-                            size="icon"
-                            variant="outline"
-                            className="h-7 w-7"
-                            onClick={() => handleQuantityChange(product.id, 1)}
-                            disabled={source ? product.quantity >= source.in_stock : false}
-                          >
-                            <PlusIcon className="h-3 w-3" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                      <TableCell className="font-medium">
-                        ${(product.quantity * product.price / 100).toFixed(2)}
-                      </TableCell>
-                      <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleRemoveProduct(product.id)}
-                        >
-                          <Trash2Icon className="h-4 w-4" />
-                          <span className="sr-only">Remove</span>
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
           )}
-          <div className="mt-4 flex items-center justify-between border-t pt-4">
+          <div className="mt-4 flex flex-col sm:flex-row items-center justify-between gap-3 border-t pt-4">
             <strong className="text-lg">Total: ${(total / 100).toFixed(2)}</strong>
             <Button
               onClick={handleCreateOrder}
               disabled={!canCreate || createOrderMutation.isPending}
               size="lg"
+              className="w-full sm:w-auto"
             >
               {createOrderMutation.isPending && <Loader2Icon className="h-4 w-4 animate-spin mr-2" />}
               Create Order

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -182,7 +182,7 @@ export default function Products() {
 
   if (isLoading) {
     return (
-      <Card className="flex flex-col gap-6 p-6">
+      <Card className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
         <CardHeader className="p-0"><div className="flex items-center justify-between"><Skeleton className="h-10 w-48" /><Skeleton className="h-9 w-32" /></div></CardHeader>
         <CardContent className="p-0 space-y-3">
           {Array.from({ length: 5 }).map((_, i) => (<div key={i} className="flex items-center gap-4"><Skeleton className="h-4 w-32" /><Skeleton className="h-4 w-48" /><Skeleton className="h-4 w-16" /><Skeleton className="h-4 w-12" /><Skeleton className="h-8 w-20" /></div>))}
@@ -193,7 +193,7 @@ export default function Products() {
 
   return (
     <>
-      <Card className="flex flex-col gap-6 p-6">
+      <Card className="flex flex-col gap-4 p-3 sm:gap-6 sm:p-6">
         <CardHeader className="p-0">
           <SearchFilter
             search={searchTerm}
@@ -238,8 +238,8 @@ export default function Products() {
             <div className="grid gap-4 py-4">
               <form.Field name="name">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="name" className="text-right">Name</Label>
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
+                    <Label htmlFor="name" className="sm:text-right">Name</Label>
                     <div className="col-span-3">
                       <Input
                         id="name"
@@ -254,16 +254,16 @@ export default function Products() {
               </form.Field>
               <form.Field name="description">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="description" className="text-right">Description</Label>
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
+                    <Label htmlFor="description" className="sm:text-right">Description</Label>
                     <Input id="description" value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} className="col-span-3" />
                   </div>
                 )}
               </form.Field>
               <form.Field name="price">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="price" className="text-right">Price</Label>
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
+                    <Label htmlFor="price" className="sm:text-right">Price</Label>
                     <div className="col-span-3">
                       <Input
                         id="price"
@@ -280,8 +280,8 @@ export default function Products() {
               </form.Field>
               <form.Field name="in_stock">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="in_stock" className="text-right">In Stock</Label>
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
+                    <Label htmlFor="in_stock" className="sm:text-right">In Stock</Label>
                     <div className="col-span-3">
                       <Input
                         id="in_stock"
@@ -297,8 +297,8 @@ export default function Products() {
               </form.Field>
               <form.Field name="category">
                 {(field) => (
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="category" className="text-right">Category</Label>
+                  <div className="flex flex-col sm:grid sm:grid-cols-4 sm:items-center gap-2 sm:gap-4">
+                    <Label htmlFor="category" className="sm:text-right">Category</Label>
                     <Select value={field.state.value} onValueChange={(value) => field.handleChange(value)}>
                       <SelectTrigger className="col-span-3"><SelectValue placeholder="Select a category" /></SelectTrigger>
                       <SelectContent>

--- a/src/components/admin-layout.tsx
+++ b/src/components/admin-layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -21,7 +21,6 @@ import { usePathname } from "next/navigation";
 import Image from "next/image";
 import {
   Package2Icon,
-  SearchIcon,
   LayoutDashboardIcon,
   DollarSignIcon,
   PackageIcon,
@@ -29,6 +28,8 @@ import {
   UsersIcon,
   ShoppingBagIcon,
   CreditCardIcon,
+  MenuIcon,
+  XIcon,
   type LucideIcon,
 } from "lucide-react";
 
@@ -56,52 +57,101 @@ const pageNames: Record<string, string> = Object.fromEntries(
 
 export function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-muted/40">
-      <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4">
+      <header className="sticky top-0 z-30 flex h-14 items-center gap-2 border-b bg-background px-3 sm:px-4 sm:gap-4">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="sm:hidden shrink-0"
+          onClick={() => setMobileMenuOpen(true)}
+        >
+          <MenuIcon className="h-5 w-5" />
+          <span className="sr-only">Open menu</span>
+        </Button>
         <Link
           href="/admin"
-          className="flex items-center gap-2 text-lg font-semibold"
+          className="hidden sm:flex items-center gap-2 text-lg font-semibold"
         >
           <Package2Icon className="h-6 w-6" />
           <span className="sr-only">Admin Panel</span>
         </Link>
-        <h1 className="text-xl font-bold">{pageNames[pathname]}</h1>
-        <div className="relative ml-auto flex-1 md:grow-0">
-          <SearchIcon className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search..."
-            className="w-full rounded-lg bg-background pl-8 md:w-[200px] lg:w-[336px]"
-          />
+        <h1 className="text-lg sm:text-xl font-bold truncate">{pageNames[pathname]}</h1>
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                className="overflow-hidden rounded-full shrink-0"
+              >
+                <Image
+                  src="/placeholder-user.jpg"
+                  width={36}
+                  height={36}
+                  alt="Avatar"
+                  className="overflow-hidden rounded-full"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>My Account</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>Settings</DropdownMenuItem>
+              <DropdownMenuItem>Support</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => logout()}>Logout</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              className="overflow-hidden rounded-full"
-            >
-              <Image
-                src="/placeholder-user.jpg"
-                width={36}
-                height={36}
-                alt="Avatar"
-                className="overflow-hidden rounded-full"
-              />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>My Account</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem>Settings</DropdownMenuItem>
-            <DropdownMenuItem>Support</DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => logout()}>Logout</DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </header>
+
+      {/* Mobile drawer overlay */}
+      {mobileMenuOpen && (
+        <div className="fixed inset-0 z-50 sm:hidden">
+          <div
+            className="fixed inset-0 bg-black/50"
+            onClick={() => setMobileMenuOpen(false)}
+          />
+          <nav className="fixed inset-y-0 left-0 w-64 bg-background border-r p-4 flex flex-col gap-2 overflow-y-auto">
+            <div className="flex items-center justify-between mb-4">
+              <Link
+                href="/admin"
+                className="flex items-center gap-2 text-lg font-semibold"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <Package2Icon className="h-6 w-6" />
+                <span>FinOpenPOS</span>
+              </Link>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <XIcon className="h-5 w-5" />
+              </Button>
+            </div>
+            {navItems.map(({ href, label, icon: Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                onClick={() => setMobileMenuOpen(false)}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                  pathname === href
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                }`}
+              >
+                <Icon className="h-5 w-5 shrink-0" />
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
+
       <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-14">
         <aside className="fixed mt-[56px] inset-y-0 left-0 z-10 hidden w-14 flex-col border-r bg-background sm:flex">
           <nav className="flex flex-col items-center gap-4 px-2 sm:py-5">
@@ -127,7 +177,7 @@ export function AdminLayout({ children }: { children: React.ReactNode }) {
             </TooltipProvider>
           </nav>
         </aside>
-        <main className="flex-1 p-4 sm:px-6 sm:py-0">{children}</main>
+        <main className="flex-1 p-3 sm:px-6 sm:py-0 overflow-x-hidden">{children}</main>
       </div>
     </div>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-top-[48%] rounded-lg max-h-[90vh] overflow-y-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Added mobile hamburger menu with slide-out drawer navigation in admin layout
- Fixed dialog component for proper mobile display (width, max-height, padding)
- Stacked form fields vertically on mobile across all CRUD pages (products, customers, orders, payment-methods, cashier)
- Made POS page fully responsive (stacked comboboxes, scrollable cart table, full-width button)
- Fixed dashboard chart overflow on mobile with `min-w-0` and `overflow-hidden`
- Reduced card padding on mobile (`p-3` vs `p-6`)

## Test plan
- [x] Tested all pages on 375x812 viewport with Playwright
- [x] Mobile navigation drawer opens/closes correctly
- [x] Forms stack vertically on mobile
- [x] Charts don't cause horizontal scroll
- [x] POS cart table scrolls horizontally when needed