### PR TITLE
feat(deploy): add prepare-prod script and production Docker setup

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,55 @@
+FROM alpine:3.21 AS base
+RUN apk add --no-cache nodejs npm postgresql postgresql-client && npm i -g bun
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+FROM base AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Run prepare-prod to switch from PGLite to node-postgres
+RUN bun scripts/prepare-prod.ts
+# Reinstall after dependency changes (pg added, pglite removed)
+RUN bun install
+
+ENV BETTER_AUTH_SECRET=build-placeholder
+ENV BETTER_AUTH_URL=http://localhost:3000
+ENV DATABASE_URL=postgresql://finopenpos:finopenpos@localhost:5432/finopenpos
+
+RUN bun run --bun next build
+
+FROM base AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Setup PostgreSQL data directory
+RUN mkdir -p /run/postgresql /var/lib/postgresql/data \
+    && chown -R postgres:postgres /run/postgresql /var/lib/postgresql/data
+
+# Init PostgreSQL cluster
+RUN su postgres -c "initdb -D /var/lib/postgresql/data"
+
+# Configure pg_hba for local trust auth
+RUN echo "local all all trust" > /var/lib/postgresql/data/pg_hba.conf \
+    && echo "host all all 127.0.0.1/32 trust" >> /var/lib/postgresql/data/pg_hba.conf \
+    && echo "host all all ::1/128 trust" >> /var/lib/postgresql/data/pg_hba.conf
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/package.json ./
+COPY --from=build /app/next.config.mjs ./
+COPY --from=build /app/drizzle.config.ts ./
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/src ./src
+
+COPY docker-entrypoint-prod.sh /docker-entrypoint-prod.sh
+RUN chmod +x /docker-entrypoint-prod.sh
+
+EXPOSE 3111
+
+CMD ["/docker-entrypoint-prod.sh"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Open http://localhost:3000 and use the **Fill demo credentials** button to sign 
 | `bun run db:ensure` | Detect and auto-clean corrupted PGLite data |
 | `bun test` | Run all E2E tests (tRPC routers) |
 | `bun run test:coverage` | Run tests with coverage report |
+| `bun run prepare-prod` | Migrate from PGLite to real PostgreSQL |
 
 ## Project Structure
 
@@ -297,6 +298,25 @@ PGLite runs full PostgreSQL via WASM, directly in the Node.js process. Data is s
 ### Migrating to PostgreSQL
 
 When the project grows and needs a real database, migration is straightforward because Drizzle ORM abstracts the data access layer — the schema is identical.
+
+#### Automatic migration
+
+Run the built-in script that handles all steps automatically:
+
+```bash
+bun run prepare-prod
+```
+
+Then set `DATABASE_URL` in your `.env` file and run:
+
+```bash
+bun run db:push
+bun run dev
+```
+
+#### Manual migration
+
+If you prefer to do it step by step:
 
 #### 1. Install the PostgreSQL driver
 

--- a/README.ptBR.md
+++ b/README.ptBR.md
@@ -84,6 +84,7 @@ Acesse http://localhost:3000 e use o botão **Fill demo credentials** para entra
 | `bun run db:ensure` | Detecta e limpa PGLite corrompido automaticamente |
 | `bun test` | Roda todos os testes E2E (routers tRPC) |
 | `bun run test:coverage` | Roda testes com relatório de cobertura |
+| `bun run prepare-prod` | Migra do PGLite para PostgreSQL real |
 
 ## Estrutura do Projeto
 
@@ -297,6 +298,25 @@ O PGLite roda PostgreSQL completo via WASM, direto no processo do Node.js. Os da
 ### Migrando para PostgreSQL
 
 Quando o projeto crescer e precisar de um banco real, a migração é simples porque o Drizzle ORM abstrai a camada de acesso — o schema é idêntico.
+
+#### Migração automática
+
+Execute o script que faz todos os passos automaticamente:
+
+```bash
+bun run prepare-prod
+```
+
+Depois configure `DATABASE_URL` no seu `.env` e rode:
+
+```bash
+bun run db:push
+bun run dev
+```
+
+#### Migração manual
+
+Se preferir fazer passo a passo:
 
 #### 1. Instale o driver do PostgreSQL
 

--- a/compose-production.yaml
+++ b/compose-production.yaml
@@ -1,0 +1,18 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.production
+    environment:
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-finopenpos}
+      - PORT=3111
+    ports:
+      - "3111:3111"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  pg_data:

--- a/docker-entrypoint-prod.sh
+++ b/docker-entrypoint-prod.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+PGDATA="/var/lib/postgresql/data"
+DB_NAME="finopenpos"
+DB_USER="finopenpos"
+DB_PASS="${POSTGRES_PASSWORD:-finopenpos}"
+
+export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:5432/${DB_NAME}"
+
+# Ensure PGDATA ownership (volume may mount as root)
+chown -R postgres:postgres ${PGDATA} /run/postgresql
+
+# Init cluster if empty (first run with fresh volume)
+if [ ! -f "${PGDATA}/PG_VERSION" ]; then
+  su postgres -c "initdb -D ${PGDATA} --auth=trust"
+  echo "local all all trust" > ${PGDATA}/pg_hba.conf
+  echo "host all all 127.0.0.1/32 trust" >> ${PGDATA}/pg_hba.conf
+  echo "host all all ::1/128 trust" >> ${PGDATA}/pg_hba.conf
+fi
+
+# Start PostgreSQL
+touch /var/log/postgresql.log && chown postgres:postgres /var/log/postgresql.log
+su postgres -c "pg_ctl -D ${PGDATA} -l /var/log/postgresql.log start -w"
+
+# Create user and database if they don't exist
+su postgres -c "psql -tc \"SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'\" | grep -q 1 \
+  || psql -c \"CREATE ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASS}'\""
+su postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'\" | grep -q 1 \
+  || psql -c \"CREATE DATABASE ${DB_NAME} OWNER ${DB_USER}\""
+
+# Push schema
+bun drizzle-kit push
+
+# Start Next.js
+exec bun next start

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "db:ensure": "bun scripts/ensure-db.ts",
     "db:push": "drizzle-kit push && bun scripts/generate-er.ts",
     "test": "bun test src/lib/trpc/routers/__tests__",
-    "test:coverage": "bun test --coverage src/lib/trpc/routers/__tests__"
+    "test:coverage": "bun test --coverage src/lib/trpc/routers/__tests__",
+    "prepare-prod": "bun scripts/prepare-prod.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.15",

--- a/scripts/prepare-prod.ts
+++ b/scripts/prepare-prod.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * prepare-prod.ts
+ *
+ * Converts the project from PGLite (embedded PostgreSQL WASM) to a real
+ * PostgreSQL server, following the migration steps documented in README.md.
+ *
+ * What it does:
+ *   1. Installs `pg` and removes `@electric-sql/pglite`
+ *   2. Rewrites `src/lib/db/index.ts` to use node-postgres
+ *   3. Rewrites `drizzle.config.ts` to use a DATABASE_URL
+ *   4. Removes `db:ensure` from dev/build scripts in package.json
+ *   5. Removes `serverExternalPackages` from next.config.mjs
+ *   6. Deletes `scripts/ensure-db.ts`
+ *   7. Adds DATABASE_URL to .env.example
+ *
+ * Usage:
+ *   bun scripts/prepare-prod.ts
+ */
+
+import { $ } from "bun";
+import { readFileSync, writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+function readFile(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), "utf-8");
+}
+
+function writeFile(relativePath: string, content: string): void {
+  writeFileSync(join(ROOT, relativePath), content, "utf-8");
+}
+
+function deleteFile(relativePath: string): void {
+  const fullPath = join(ROOT, relativePath);
+  if (existsSync(fullPath)) {
+    unlinkSync(fullPath);
+    console.log(`  Deleted ${relativePath}`);
+  }
+}
+
+async function main() {
+  console.log("\n=== prepare-prod: Converting PGLite → PostgreSQL ===\n");
+
+  // Step 1: Install pg, remove pglite
+  console.log("1. Installing pg and removing @electric-sql/pglite...");
+  await $`cd ${ROOT} && bun add pg && bun add -d @types/pg && bun remove @electric-sql/pglite`.quiet();
+  console.log("  Done.\n");
+
+  // Step 2: Rewrite src/lib/db/index.ts
+  console.log("2. Rewriting src/lib/db/index.ts...");
+  writeFile(
+    "src/lib/db/index.ts",
+    `import { drizzle } from "drizzle-orm/node-postgres";
+import * as schema from "./schema";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable is required. Set it in your .env file.");
+}
+
+export const db = drizzle(process.env.DATABASE_URL, { schema });
+`
+  );
+  console.log("  Done.\n");
+
+  // Step 3: Rewrite drizzle.config.ts
+  console.log("3. Rewriting drizzle.config.ts...");
+  writeFile(
+    "drizzle.config.ts",
+    `import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/lib/db/schema.ts",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});
+`
+  );
+  console.log("  Done.\n");
+
+  // Step 4: Update package.json scripts
+  console.log("4. Updating package.json scripts...");
+  const pkg = JSON.parse(readFile("package.json"));
+
+  // Remove db:ensure from dev and build scripts
+  if (pkg.scripts.dev) {
+    pkg.scripts.dev = pkg.scripts.dev.replace("bun run db:ensure && ", "");
+  }
+  if (pkg.scripts.build) {
+    pkg.scripts.build = pkg.scripts.build.replace("bun run db:ensure && ", "");
+  }
+
+  // Remove db:ensure script itself
+  delete pkg.scripts["db:ensure"];
+
+  // Add prepare-prod script if not present
+  pkg.scripts["prepare-prod"] = "bun scripts/prepare-prod.ts";
+
+  writeFile("package.json", JSON.stringify(pkg, null, 2) + "\n");
+  console.log("  Done.\n");
+
+  // Step 5: Remove serverExternalPackages from next.config.mjs
+  console.log("5. Updating next.config.mjs...");
+  let nextConfig = readFile("next.config.mjs");
+  // Remove the serverExternalPackages line
+  nextConfig = nextConfig.replace(
+    /\s*serverExternalPackages:\s*\[.*?\],?\n?/,
+    "\n"
+  );
+  // Clean up empty config object
+  nextConfig = nextConfig.replace(
+    /const nextConfig = \{\s*\n\s*\};/,
+    "const nextConfig = {};"
+  );
+  writeFile("next.config.mjs", nextConfig);
+  console.log("  Done.\n");
+
+  // Step 6: Delete scripts/ensure-db.ts
+  console.log("6. Deleting scripts/ensure-db.ts...");
+  deleteFile("scripts/ensure-db.ts");
+  console.log("");
+
+  // Step 7: Add DATABASE_URL to .env.example
+  console.log("7. Updating .env.example...");
+  let envExample = readFile(".env.example");
+  if (!envExample.includes("DATABASE_URL")) {
+    envExample += "DATABASE_URL=postgresql://user:password@localhost:5432/finopenpos\n";
+    writeFile(".env.example", envExample);
+  }
+  console.log("  Done.\n");
+
+  console.log("=== Migration complete! ===\n");
+  console.log("Next steps:");
+  console.log("  1. Set DATABASE_URL in your .env file");
+  console.log("  2. Run: bun run db:push");
+  console.log("  3. Run: bun run dev");
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `bun run prepare-prod` script that automates PGLite → PostgreSQL migration
- Add `Dockerfile.production` + `compose-production.yaml` running PostgreSQL and Next.js in a single container
- Add `docker-entrypoint-prod.sh` that initializes PostgreSQL, creates user/database, pushes schema, and starts Next.js
- Document the new command in both README.md and README.ptBR.md (automatic + manual migration preserved)

## Test plan
- [x] `bun scripts/prepare-prod.ts` runs successfully and transforms all files
- [x] `docker compose -f compose-production.yaml build` builds without errors
- [x] `docker compose -f compose-production.yaml up -d` starts container
- [x] PostgreSQL initializes, role/database created, schema pushed
- [x] HTTP 200 on `http://localhost:3111/login` with proper env vars
- [x] Volume persistence works across restarts