### PR TITLE
fix(fiscal): correct ICMS decimal precision per SEFAZ XSD

### DIFF
--- a/src/lib/fiscal/__tests__/make-ported.test.ts
+++ b/src/lib/fiscal/__tests__/make-ported.test.ts
@@ -1488,12 +1488,12 @@ describe("tagICMSST — ported from test_tagICMSST", () => {
 describe("tagICMSSN — ported from test_tagICMSSN_*", () => {
   it("test_tagICMSSN_101 — ICMSSN101 with credit", () => {
     // PHP: orig=0, CSOSN=101, pCredSN=3, vCredICMSSN=4
-    // pCredSN=3 → fc(300,2)="3.00", vCredICMSSN=4 → fc(400)="4.00"
+    // pCredSN=3 → fc(300,4)="3.0000" (TDec_0302a04: 2-4dp), vCredICMSSN=4 → fc(400)="4.00"
     const { xml } = buildIcmsXml({
       taxRegime: 1,
       orig: "0",
       CSOSN: "101",
-      pCredSN: 300,         // "3.00"
+      pCredSN: 300,         // "3.0000"
       vCredICMSSN: 400,     // "4.00"
     });
 
@@ -1502,7 +1502,7 @@ describe("tagICMSSN — ported from test_tagICMSSN_*", () => {
     expectXmlContains(xml, {
       orig: "0",
       CSOSN: "101",
-      pCredSN: "3.00",
+      pCredSN: "3.0000",
       vCredICMSSN: "4.00",
     });
   });

--- a/src/lib/fiscal/__tests__/tax-coverage-ported.test.ts
+++ b/src/lib/fiscal/__tests__/tax-coverage-ported.test.ts
@@ -276,8 +276,8 @@ describe("TaxCoverageTest — ICMS CST", () => {
       vFCPDif: 60,
       vFCPEfet: 120,
     });
-    expectXmlContains(xml, "<ICMS51>", "<pDif>", "<vICMSDif>", "<cBenefRBC>",
-      "<pFCPDif>", "<vFCPDif>", "<vFCPEfet>");
+    expectXmlContains(xml, "<ICMS51>", "<pDif>33.3300</pDif>", "<vICMSDif>5.40</vICMSDif>", "<cBenefRBC>",
+      "<pFCPDif>33.3300</pFCPDif>", "<vFCPDif>0.60</vFCPDif>", "<vFCPEfet>1.20</vFCPEfet>");
   });
 
   it("testICMS51Minimal — CST 51 minimal", () => {
@@ -432,8 +432,9 @@ describe("TaxCoverageTest — ICMS CST", () => {
       vICMSSTDeson: 100,
       motDesICMSST: "3",
     });
-    expectXmlContains(xml, "<ICMS90>", "<cBenefRBC>", "<vICMSOp>", "<pDif>",
-      "<vICMSDif>", "<pFCPDif>", "<vFCPDif>", "<vFCPEfet>",
+    expectXmlContains(xml, "<ICMS90>", "<cBenefRBC>", "<vICMSOp>",
+      "<pDif>33.3300</pDif>", "<vICMSDif>5.40</vICMSDif>",
+      "<pFCPDif>33.3300</pFCPDif>", "<vFCPDif>0.67</vFCPDif>", "<vFCPEfet>1.33</vFCPEfet>",
       "<vICMSSTDeson>", "<motDesICMSST>");
   });
 
@@ -523,7 +524,7 @@ describe("TaxCoverageTest — ICMSSN CSOSN", () => {
       pCredSN: 200,
       vCredICMSSN: 200,
     });
-    expectXmlContains(xml, "<ICMSSN101>", "<pCredSN>");
+    expectXmlContains(xml, "<ICMSSN101>", "<pCredSN>2.0000</pCredSN>");
   });
 
   it("testICMSSN102 — CSOSN 102", () => {

--- a/src/lib/fiscal/tax-icms.ts
+++ b/src/lib/fiscal/tax-icms.ts
@@ -599,7 +599,7 @@ function calcCst51(d: IcmsData, t: IcmsTotals): CstResult {
     optionalField("vBCFCP", formatCentsOrNull(d.vBCFCP)),
     optionalField("pFCP", formatCentsOrNull(d.pFCP, 4)),
     optionalField("vFCP", formatCentsOrNull(d.vFCP)),
-    optionalField("pFCPDif", formatCentsOrNull(d.pFCPDif)),
+    optionalField("pFCPDif", formatCentsOrNull(d.pFCPDif, 4)),
     optionalField("vFCPDif", formatCentsOrNull(d.vFCPDif)),
     optionalField("vFCPEfet", formatCentsOrNull(d.vFCPEfet)),
   ]) };
@@ -704,7 +704,7 @@ function calcCst90(d: IcmsData, t: IcmsTotals): CstResult {
     optionalField("cBenefRBC", d.cBenefRBC),
     optionalField("pICMS", formatCentsOrNull(d.pICMS, 4)),
     optionalField("vICMSOp", formatCentsOrNull(d.vICMSOp)),
-    optionalField("pDif", formatCentsOrNull(d.pDif)),
+    optionalField("pDif", formatCentsOrNull(d.pDif, 4)),
     optionalField("vICMSDif", formatCentsOrNull(d.vICMSDif)),
     optionalField("vICMS", formatCentsOrNull(d.vICMS)),
     ...fcpFields(d),
@@ -758,7 +758,7 @@ function calcCsosn101(d: IcmsData, _t: IcmsTotals): CstResult {
   return { variantTag: "ICMSSN101", fields: filterFields([
     requiredField("orig", d.orig),
     requiredField("CSOSN", d.CSOSN),
-    requiredField("pCredSN", formatCentsOrNull(d.pCredSN, 2)),
+    requiredField("pCredSN", formatCentsOrNull(d.pCredSN, 4)),
     requiredField("vCredICMSSN", formatCentsOrNull(d.vCredICMSSN)),
   ]) };
 }


### PR DESCRIPTION
## Summary
- Fix decimal precision for `pDif` (CST 90), `pFCPDif` (CST 51), and `pCredSN` (CSOSN 101) to use 4 decimal places as defined by the SEFAZ XSD types (`TDec_0302a04`, `TDec_0302a04Opc`, `TDec_0302a04Max100`)
- Update tests to assert actual formatted values (e.g. `<pDif>33.3300</pDif>`) instead of just tag presence, so future regressions break tests correctly

## Context
Found via cross-analysis of sped-nfe source against `PL_009_V4` XSD schemas during [nfephp-org/sped-nfe#1313](https://github.com/nfephp-org/sped-nfe/pull/1313) review. Full bug report: [nfephp-org/sped-nfe#1314](https://github.com/nfephp-org/sped-nfe/issues/1314).

## Test plan
- [x] `bun test src/lib/fiscal/__tests__/` — 754 pass, 0 fail
- [x] Verified XSD patterns: `TDec_0302a04` accepts 2-4dp, `TDec_1302` requires exactly 2dp