### PR TITLE
feat(www): add landing page app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,15 @@ COPY packages/db/package.json ./packages/db/
 COPY packages/env/package.json ./packages/env/
 COPY packages/fiscal/package.json ./packages/fiscal/
 COPY packages/ui/package.json ./packages/ui/
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM base AS build
 WORKDIR /app
 COPY --from=deps /app .
 COPY . .
+
+# Run postinstall scripts (fumadocs-mdx needs source files)
+RUN cd apps/docs && bunx fumadocs-mdx
 
 ENV BETTER_AUTH_SECRET=build-placeholder
 ENV BETTER_AUTH_URL=http://localhost:3001
@@ -66,6 +69,9 @@ COPY --from=build /app/apps/www/next.config.ts ./apps/www/
 COPY --from=build /app/apps/docs/.next ./apps/docs/.next
 COPY --from=build /app/apps/docs/package.json ./apps/docs/
 COPY --from=build /app/apps/docs/next.config.mjs ./apps/docs/
+
+# Copy packages source (needed by drizzle-kit at runtime)
+COPY --from=build /app/packages ./packages
 
 COPY --from=build /app/package.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.21 AS base
-RUN apk add --no-cache nodejs npm && npm i -g bun
+RUN apk add --no-cache nodejs npm nginx && npm i -g bun
 
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY apps/web/package.json ./apps/web/
+COPY apps/www/package.json ./apps/www/
+COPY apps/docs/package.json ./apps/docs/
 COPY packages/api/package.json ./packages/api/
 COPY packages/auth/package.json ./packages/auth/
 COPY packages/config/package.json ./packages/config/
@@ -20,19 +22,33 @@ COPY --from=deps /app .
 COPY . .
 
 ENV BETTER_AUTH_SECRET=build-placeholder
-ENV BETTER_AUTH_URL=http://localhost:3000
+ENV BETTER_AUTH_URL=http://localhost:3001
 
-RUN mkdir -p apps/web/data && cd apps/web && bun run --bun next build
+ARG NEXT_PUBLIC_DOCS_URL=http://localhost:3002
+ARG NEXT_PUBLIC_API_DOCS_URL=http://localhost:3001/api/docs
+ENV NEXT_PUBLIC_DOCS_URL=$NEXT_PUBLIC_DOCS_URL
+ENV NEXT_PUBLIC_API_DOCS_URL=$NEXT_PUBLIC_API_DOCS_URL
+
+# Build web with basePath=/app
+RUN mkdir -p apps/web/data && cd apps/web && BASE_PATH=/app bun run --bun next build
+
+# Build www (no basePath, serves at /)
+RUN cd apps/www && bun run --bun next build
+
+# Build docs with basePath=/docs
+RUN cd apps/docs && BASE_PATH=/docs bun run --bun next build
 
 FROM base AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 
-# Copy full node_modules tree (root + workspace hoisted)
+# Copy node_modules
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/apps/www/node_modules ./apps/www/node_modules
+COPY --from=deps /app/apps/docs/node_modules ./apps/docs/node_modules
 
-# Copy built app
+# Copy built web app
 COPY --from=build /app/apps/web/.next ./apps/web/.next
 COPY --from=build /app/apps/web/public ./apps/web/public
 COPY --from=build /app/apps/web/package.json ./apps/web/
@@ -40,8 +56,25 @@ COPY --from=build /app/apps/web/next.config.mjs ./apps/web/
 COPY --from=build /app/apps/web/drizzle.config.ts ./apps/web/
 COPY --from=build /app/apps/web/scripts ./apps/web/scripts
 COPY --from=build /app/apps/web/src ./apps/web/src
+
+# Copy built www app
+COPY --from=build /app/apps/www/.next ./apps/www/.next
+COPY --from=build /app/apps/www/package.json ./apps/www/
+COPY --from=build /app/apps/www/next.config.ts ./apps/www/
+
+# Copy built docs app
+COPY --from=build /app/apps/docs/.next ./apps/docs/.next
+COPY --from=build /app/apps/docs/package.json ./apps/docs/
+COPY --from=build /app/apps/docs/next.config.mjs ./apps/docs/
+
 COPY --from=build /app/package.json ./
 
-WORKDIR /app/apps/web
-EXPOSE 3111
-CMD ["sh", "-c", "bun scripts/ensure-db.ts && bunx drizzle-kit push && bun next start"]
+# Nginx config
+COPY nginx.conf /etc/nginx/http.d/default.conf
+
+# Entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 80
+CMD ["/docker-entrypoint.sh"]

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -2,6 +2,7 @@ import { createMDX } from "fumadocs-mdx/next";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: process.env.BASE_PATH || "",
   reactStrictMode: true,
 };
 

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -1,6 +1,8 @@
 import { ApiReference } from "@scalar/nextjs-api-reference";
 
+const basePath = process.env.BASE_PATH || "";
+
 export const GET = ApiReference({
-  url: "/api/openapi.json",
+  url: `${basePath}/api/openapi.json`,
   theme: "kepler",
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,8 @@
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div>
-    </div>
-  );
+  if (process.env.LANDING_URL) {
+    redirect(process.env.LANDING_URL);
+  }
+  redirect("/login");
 }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,12 +5,19 @@ export async function proxy(request: NextRequest) {
   const sessionCookie = getSessionCookie(request);
   const { pathname } = request.nextUrl;
 
+  // Redirect root to landing page if LANDING_URL is set
+  if (pathname === "/" && process.env.LANDING_URL) {
+    return NextResponse.redirect(process.env.LANDING_URL);
+  }
+
   if (
     !sessionCookie &&
     !pathname.startsWith("/login") &&
     !pathname.startsWith("/signup") &&
     !pathname.startsWith("/auth") &&
-    !pathname.startsWith("/api/auth")
+    !pathname.startsWith("/api/auth") &&
+    !pathname.startsWith("/api/docs") &&
+    !pathname.startsWith("/api/openapi.json")
   ) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -2,13 +2,15 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
-/** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath: process.env.BASE_PATH || "",
-  serverExternalPackages: ["@electric-sql/pglite"],
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https" as const,
+				hostname: "avatars.githubusercontent.com",
+			},
+		],
+	},
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@finopenpos/www",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev --turbo --port 3003",
+		"build": "next build",
+		"start": "next start --port 3003"
+	},
+	"dependencies": {
+		"@finopenpos/env": "workspace:*",
+		"@finopenpos/ui": "workspace:*",
+		"lucide-react": "catalog:",
+		"next": "catalog:",
+		"next-intl": "^4.8.3",
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	},
+	"devDependencies": {
+		"@finopenpos/config": "workspace:*",
+		"@tailwindcss/postcss": "^4.2.1",
+		"@types/react": "catalog:",
+		"@types/react-dom": "catalog:",
+		"postcss": "^8.5.6",
+		"tailwindcss": "catalog:",
+		"typescript": "^5"
+	}
+}

--- a/apps/www/postcss.config.mjs
+++ b/apps/www/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+};
+
+export default config;

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -1,0 +1,177 @@
+@import "tailwindcss";
+
+@source "../../../../packages/ui/src";
+
+:root {
+	--neon-bg-primary: #0c0d0d;
+	--neon-bg-secondary: #0a0a0b;
+	--neon-bg-tertiary: #111215;
+	--neon-bg-card: #151617;
+	--neon-bg-light: #e4f1eb;
+	--neon-bg-light-alt: #ebf5f0;
+	--neon-bg-light-accent: #cae6d9;
+	--neon-green-primary: #2c6d4c;
+	--neon-green-accent: #34d59a;
+	--neon-green-dark: #285d49;
+	--neon-green-mid: #37c38f;
+	--neon-green-glow: rgba(57, 165, 125, 0.6);
+	--neon-text-primary: #ffffff;
+	--neon-text-secondary: #c9cbcf;
+	--neon-text-muted: #94979e;
+	--neon-text-dim: #a3a6b3;
+	--neon-border: #1a1a1a;
+}
+
+@theme inline {
+	--font-sans: var(--font-sans);
+	--font-display: var(--font-display);
+	--font-mono: var(--font-mono);
+	--color-neon-primary: var(--neon-bg-primary);
+	--color-neon-secondary: var(--neon-bg-secondary);
+	--color-neon-tertiary: var(--neon-bg-tertiary);
+	--color-neon-card: var(--neon-bg-card);
+	--color-neon-light: var(--neon-bg-light);
+	--color-neon-light-alt: var(--neon-bg-light-alt);
+	--color-neon-light-accent: var(--neon-bg-light-accent);
+	--color-neon-green: var(--neon-green-primary);
+	--color-neon-accent: var(--neon-green-accent);
+	--color-neon-green-dark: var(--neon-green-dark);
+	--color-neon-green-mid: var(--neon-green-mid);
+	--color-neon-text: var(--neon-text-primary);
+	--color-neon-text-secondary: var(--neon-text-secondary);
+	--color-neon-text-muted: var(--neon-text-muted);
+	--color-neon-text-dim: var(--neon-text-dim);
+	--color-neon-border: var(--neon-border);
+	--animate-fade-in-up: fade-in-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+	--animate-fade-in: fade-in 0.6s ease-out both;
+	--animate-glow-pulse: glow-pulse 4s ease-in-out infinite;
+}
+
+@keyframes fade-in-up {
+	from {
+		opacity: 0;
+		transform: translateY(32px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes glow-pulse {
+	0%, 100% { opacity: 0.4; }
+	50% { opacity: 0.8; }
+}
+
+@keyframes grid-move {
+	0% { transform: perspective(800px) rotateX(65deg) translateY(0); }
+	100% { transform: perspective(800px) rotateX(65deg) translateY(50px); }
+}
+
+@keyframes float {
+	0%, 100% { transform: translateY(0); }
+	50% { transform: translateY(-12px); }
+}
+
+@keyframes shimmer {
+	0% { background-position: -200% 0; }
+	100% { background-position: 200% 0; }
+}
+
+@keyframes marquee {
+	0% { transform: translateX(0); }
+	100% { transform: translateX(-50%); }
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body {
+	background-color: var(--neon-bg-primary);
+	color: var(--neon-text-primary);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+	background-color: var(--neon-green-primary);
+	color: var(--neon-text-primary);
+}
+
+/* Noise texture overlay */
+.noise::after {
+	content: "";
+	position: fixed;
+	inset: 0;
+	z-index: 9999;
+	pointer-events: none;
+	opacity: 0.015;
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	background-repeat: repeat;
+	background-size: 256px 256px;
+}
+
+/* Perspective grid */
+.perspective-grid {
+	background-image:
+		linear-gradient(rgba(52, 213, 154, 0.05) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(52, 213, 154, 0.05) 1px, transparent 1px);
+	background-size: 50px 50px;
+	transform: perspective(800px) rotateX(65deg);
+	transform-origin: center top;
+	animation: grid-move 4s linear infinite;
+	mask-image: linear-gradient(to bottom, transparent, white 20%, white 80%, transparent);
+}
+
+/* Gradient text */
+.gradient-text {
+	background: linear-gradient(135deg, #34d59a 0%, #37c38f 50%, #2c6d4c 100%);
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	background-clip: text;
+}
+
+/* Shimmer button */
+.btn-shimmer {
+	position: relative;
+	overflow: hidden;
+}
+.btn-shimmer::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+	background-size: 200% 100%;
+	animation: shimmer 3s ease-in-out infinite;
+}
+
+/* Bento card base */
+.bento-card {
+	background: linear-gradient(135deg, rgba(17,18,21,0.8), rgba(21,22,23,0.6));
+	border: 1px solid rgba(26,26,26,0.8);
+	backdrop-filter: blur(8px);
+	transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.bento-card:hover {
+	border-color: rgba(44,109,76,0.4);
+	box-shadow: 0 0 40px rgba(44,109,76,0.08), inset 0 1px 0 rgba(255,255,255,0.03);
+	transform: translateY(-2px);
+}
+
+/* Glow line */
+.glow-line {
+	height: 1px;
+	background: linear-gradient(90deg, transparent, var(--neon-green-accent), transparent);
+	box-shadow: 0 0 20px var(--neon-green-glow), 0 0 60px rgba(52,213,154,0.2);
+}
+
+:focus-visible {
+	outline: 2px solid var(--neon-green-accent);
+	outline-offset: 2px;
+}

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+import { Inter, Outfit, JetBrains_Mono } from "next/font/google";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
+import "./globals.css";
+
+const inter = Inter({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-sans",
+});
+
+const outfit = Outfit({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-display",
+});
+
+const jetbrains = JetBrains_Mono({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-mono",
+});
+
+export const metadata: Metadata = {
+	title: "FinOpenPOS — Open-Source Point of Sale",
+	description:
+		"The open-source POS system Brazil deserves. Built with Next.js, PGLite, and modern web technologies.",
+	openGraph: {
+		title: "FinOpenPOS — Open-Source Point of Sale",
+		description: "The open-source POS system Brazil deserves.",
+		type: "website",
+	},
+};
+
+export default async function RootLayout({
+	children,
+}: { children: React.ReactNode }) {
+	const locale = await getLocale();
+	const messages = await getMessages();
+
+	return (
+		<html lang={locale} className="dark scroll-smooth">
+			<body
+				className={`${inter.variable} ${outfit.variable} ${jetbrains.variable} noise font-sans bg-[#0C0D0D] text-white antialiased`}
+			>
+				<NextIntlClientProvider locale={locale} messages={messages}>
+					{children}
+				</NextIntlClientProvider>
+			</body>
+		</html>
+	);
+}

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -1,0 +1,27 @@
+import Header from "@/components/header";
+import Footer from "@/components/footer";
+import Hero from "@/components/sections/hero";
+import Problem from "@/components/sections/problem";
+import TechStack from "@/components/sections/tech-stack";
+import Features from "@/components/sections/features";
+import SocialProof from "@/components/sections/social-proof";
+import GettingStarted from "@/components/sections/getting-started";
+import CTA from "@/components/sections/cta";
+
+export default function Home() {
+	return (
+		<>
+			<Header />
+			<main>
+				<Hero />
+				<Problem />
+				<TechStack />
+				<Features />
+				<SocialProof />
+				<GettingStarted />
+				<CTA />
+			</main>
+			<Footer />
+		</>
+	);
+}

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -1,0 +1,48 @@
+import { getTranslations } from "next-intl/server";
+import { links } from "@/lib/links";
+
+export default async function Footer() {
+	const t = await getTranslations("footer");
+
+	return (
+		<footer className="border-t border-[#1a1a1a] py-8">
+			<div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 sm:flex-row">
+				<p className="text-[13px] text-[#4E5159]">
+					{t("builtWith")}{" "}
+					<span className="text-[#64676F]">Next.js, PGLite, Drizzle</span>{" "}
+					{t("by")}
+				</p>
+				<div className="flex gap-6">
+					<a
+						href={links.github}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-[13px] text-[#4E5159] transition-colors hover:text-[#94979E]"
+					>
+						{t("github")}
+					</a>
+					<a
+						href={links.docs}
+						className="text-[13px] text-[#4E5159] transition-colors hover:text-[#94979E]"
+					>
+						{t("docs")}
+					</a>
+					<a
+						href={links.apiDocs}
+						className="text-[13px] text-[#4E5159] transition-colors hover:text-[#94979E]"
+					>
+						API
+					</a>
+					<a
+						href={links.license}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-[13px] text-[#4E5159] transition-colors hover:text-[#94979E]"
+					>
+						{t("license")}
+					</a>
+				</div>
+			</div>
+		</footer>
+	);
+}

--- a/apps/www/src/components/header.tsx
+++ b/apps/www/src/components/header.tsx
@@ -1,0 +1,71 @@
+import { useTranslations } from "next-intl";
+import { links } from "@/lib/links";
+import { LocaleSwitcher } from "./locale-switcher";
+import { MobileMenu } from "./mobile-menu";
+
+const NAV_LINKS = [
+	{ href: "#features", key: "features" as const },
+	{ href: links.docs, key: "docs" as const },
+	{ href: links.apiDocs, key: "apiDocs" as const },
+	{ href: links.github, key: "github" as const },
+];
+
+export default function Header() {
+	const t = useTranslations("header");
+
+	return (
+		<header className="sticky top-0 z-50 border-neon-border border-b bg-[#0C0D0D]/80 backdrop-blur-[16px]">
+			<nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
+				{/* Logo */}
+				<a href="/" className="group flex items-center gap-2">
+					<span className="relative flex h-1.5 w-1.5">
+						<span className="absolute inline-flex h-full w-full animate-[pulse_2s_ease-in-out_infinite] rounded-full bg-neon-accent opacity-75" />
+						<span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-neon-accent shadow-[0_0_8px_rgba(52,213,154,0.6)]" />
+					</span>
+					<span className="font-medium text-base text-white tracking-tight">
+						FinOpenPOS
+					</span>
+				</a>
+
+				{/* Desktop nav */}
+				<div className="hidden items-center gap-8 md:flex">
+					{NAV_LINKS.map((link) => (
+						<a
+							key={link.key}
+							href={link.href}
+							className="font-medium text-neon-text-muted text-sm transition-colors duration-200 hover:text-white"
+							{...(link.href.startsWith("http")
+								? { target: "_blank", rel: "noopener noreferrer" }
+								: {})}
+						>
+							{t(link.key)}
+						</a>
+					))}
+				</div>
+
+				{/* Desktop right section */}
+				<div className="hidden items-center gap-4 md:flex">
+					<LocaleSwitcher />
+					<a
+						href={links.github}
+						className="rounded-md bg-neon-green px-4 py-2 font-medium text-sm text-white transition-all duration-200 hover:bg-neon-accent hover:shadow-[0_0_20px_rgba(52,213,154,0.3)]"
+					>
+						{t("getStarted")}
+					</a>
+				</div>
+
+				{/* Mobile menu (client component) */}
+				<div className="md:hidden">
+					<MobileMenu
+						links={NAV_LINKS.map((link) => ({
+							...link,
+							label: t(link.key),
+						}))}
+						ctaLabel={t("getStarted")}
+						ctaHref={links.github}
+					/>
+				</div>
+			</nav>
+		</header>
+	);
+}

--- a/apps/www/src/components/locale-switcher.tsx
+++ b/apps/www/src/components/locale-switcher.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useTransition } from "react";
+import type { Locale } from "@/i18n/config";
+import { setLocale } from "@/i18n/locale";
+
+export function LocaleSwitcher() {
+	const router = useRouter();
+	const locale = useLocale();
+	const t = useTranslations("common");
+	const [isPending, startTransition] = useTransition();
+
+	const label = locale === "en" ? "EN" : "PT";
+	const nextLocale: Locale = locale === "en" ? "pt-BR" : "en";
+
+	function handleSwitch() {
+		startTransition(async () => {
+			await setLocale(nextLocale);
+			router.refresh();
+		});
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={handleSwitch}
+			disabled={isPending}
+			title={t("switchLocale")}
+			className="cursor-pointer rounded border border-neon-border px-2 py-1 font-medium text-neon-text-muted text-xs uppercase tracking-wider transition-colors duration-200 hover:text-white disabled:opacity-50"
+		>
+			{label}
+		</button>
+	);
+}

--- a/apps/www/src/components/mobile-menu.tsx
+++ b/apps/www/src/components/mobile-menu.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Menu, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { LocaleSwitcher } from "./locale-switcher";
+
+interface MobileMenuProps {
+	links: { href: string; key: string; label: string }[];
+	ctaLabel: string;
+	ctaHref: string;
+}
+
+export function MobileMenu({ links, ctaLabel, ctaHref }: MobileMenuProps) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const close = useCallback(() => setIsOpen(false), []);
+
+	// Lock body scroll when menu is open
+	useEffect(() => {
+		if (isOpen) {
+			document.body.style.overflow = "hidden";
+		} else {
+			document.body.style.overflow = "";
+		}
+		return () => {
+			document.body.style.overflow = "";
+		};
+	}, [isOpen]);
+
+	// Close on escape key
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") close();
+		}
+		if (isOpen) {
+			document.addEventListener("keydown", handleKeyDown);
+			return () => document.removeEventListener("keydown", handleKeyDown);
+		}
+	}, [isOpen, close]);
+
+	return (
+		<>
+			{/* Hamburger button */}
+			<button
+				type="button"
+				onClick={() => setIsOpen(true)}
+				className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-neon-text-muted transition-colors duration-200 hover:text-white"
+				aria-label="Open menu"
+			>
+				<Menu className="h-5 w-5" />
+			</button>
+
+			{/* Overlay */}
+			<div
+				className={`fixed inset-0 z-50 transition-all duration-300 ${
+					isOpen
+						? "visible opacity-100"
+						: "pointer-events-none invisible opacity-0"
+				}`}
+			>
+				{/* Backdrop */}
+				<button
+					type="button"
+					className="absolute inset-0 cursor-default bg-[#0C0D0D]/95 backdrop-blur-[20px]"
+					onClick={close}
+					aria-label="Close menu"
+					tabIndex={-1}
+				/>
+
+				{/* Menu panel */}
+				<div
+					className={`relative flex h-full flex-col transition-transform duration-300 ease-out ${
+						isOpen ? "translate-y-0" : "-translate-y-4"
+					}`}
+				>
+					{/* Close button row */}
+					<div className="flex h-16 items-center justify-between px-6">
+						{/* Logo duplicate for visual consistency */}
+						<div className="flex items-center gap-2">
+							<span className="relative flex h-1.5 w-1.5">
+								<span className="absolute inline-flex h-full w-full animate-[pulse_2s_ease-in-out_infinite] rounded-full bg-neon-accent opacity-75" />
+								<span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-neon-accent shadow-[0_0_8px_rgba(52,213,154,0.6)]" />
+							</span>
+							<span className="font-medium text-base text-white tracking-tight">
+								FinOpenPOS
+							</span>
+						</div>
+						<button
+							type="button"
+							onClick={close}
+							className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-neon-text-muted transition-colors duration-200 hover:text-white"
+							aria-label="Close menu"
+						>
+							<X className="h-5 w-5" />
+						</button>
+					</div>
+
+					{/* Navigation links */}
+					<div className="flex flex-1 flex-col items-center justify-center gap-8">
+						{links.map((link, i) => (
+							<a
+								key={link.key}
+								href={link.href}
+								onClick={close}
+								className={`font-medium text-2xl text-neon-text-muted transition-all duration-300 hover:text-white ${
+									isOpen
+										? "translate-y-0 opacity-100"
+										: "translate-y-4 opacity-0"
+								}`}
+								style={{
+									transitionDelay: isOpen ? `${(i + 1) * 75}ms` : "0ms",
+								}}
+								{...(link.href.startsWith("http")
+									? { target: "_blank", rel: "noopener noreferrer" }
+									: {})}
+							>
+								{link.label}
+							</a>
+						))}
+
+						{/* CTA button */}
+						<a
+							href={ctaHref}
+							onClick={close}
+							className={`mt-4 rounded-md bg-neon-green px-8 py-3 font-medium text-base text-white transition-all duration-300 hover:bg-neon-accent hover:shadow-[0_0_20px_rgba(52,213,154,0.3)] ${
+								isOpen ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+							}`}
+							style={{
+								transitionDelay: isOpen
+									? `${(links.length + 1) * 75}ms`
+									: "0ms",
+							}}
+						>
+							{ctaLabel}
+						</a>
+
+						{/* Locale switcher */}
+						<div
+							className={`mt-2 transition-all duration-300 ${
+								isOpen ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"
+							}`}
+							style={{
+								transitionDelay: isOpen
+									? `${(links.length + 2) * 75}ms`
+									: "0ms",
+							}}
+						>
+							<LocaleSwitcher />
+						</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/apps/www/src/components/sections/cta.tsx
+++ b/apps/www/src/components/sections/cta.tsx
@@ -1,0 +1,41 @@
+import { Github } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { links } from "@/lib/links";
+
+export default async function CTA() {
+	const t = await getTranslations("cta");
+
+	return (
+		<section className="relative overflow-hidden py-32 lg:py-44">
+			{/* Gradient orb */}
+			<div
+				className="pointer-events-none absolute left-1/2 top-1/2 h-[500px] w-[700px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-30 blur-[100px]"
+				style={{
+					background: "radial-gradient(circle, rgba(52,213,154,0.15) 0%, transparent 70%)",
+				}}
+			/>
+
+			<div className="relative mx-auto max-w-3xl px-6 text-center">
+				<h2 className="font-display font-medium text-[clamp(2rem,7vw,5rem)] leading-[0.95] tracking-[-0.03em] text-white">
+					{t("title")}
+				</h2>
+
+				<p className="mx-auto mt-6 max-w-md text-[17px] leading-[1.7] text-[#64676F]">
+					{t("subtitle")}
+				</p>
+
+				<div className="mt-10">
+					<a
+						href={links.github}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="btn-shimmer group inline-flex items-center gap-2.5 rounded-lg bg-[#2C6D4C] px-8 py-4 text-[15px] font-medium text-white transition-all duration-300 hover:bg-[#34D59A] hover:shadow-[0_0_50px_rgba(52,213,154,0.25)]"
+					>
+						<Github size={18} className="transition-transform duration-300 group-hover:scale-110" />
+						{t("starOnGithub")}
+					</a>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/features.tsx
+++ b/apps/www/src/components/sections/features.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+	BarChart3,
+	FileText,
+	Languages,
+	ShoppingCart,
+	Users,
+	WifiOff,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { useRef, useEffect } from "react";
+
+const features = [
+	{
+		key: "pos",
+		icon: ShoppingCart,
+		span: "md:col-span-2",
+		visual: "terminal",
+	},
+	{ key: "fiscal", icon: FileText, span: "", visual: "code" },
+	{ key: "multiTenant", icon: Users, span: "", visual: null },
+	{ key: "offline", icon: WifiOff, span: "", visual: null },
+	{ key: "dashboard", icon: BarChart3, span: "", visual: "chart" },
+	{ key: "i18n", icon: Languages, span: "md:col-span-2", visual: null },
+] as const;
+
+function MiniTerminal() {
+	return (
+		<div className="mt-4 overflow-hidden rounded-md border border-[#1a1a1a] bg-[#0A0A0B] p-3 font-mono text-[10px] leading-relaxed">
+			<span className="text-[#34D59A]">$</span>{" "}
+			<span className="text-[#64676F]">Total: R$</span>
+			<span className="text-white">42,90</span>
+			<br />
+			<span className="text-[#34D59A]">$</span>{" "}
+			<span className="text-[#64676F]">Payment:</span>{" "}
+			<span className="text-[#34D59A]">PIX</span>
+			<br />
+			<span className="text-[#34D59A]">✓</span>{" "}
+			<span className="text-[#64676F]">Sale completed</span>
+		</div>
+	);
+}
+
+function MiniCode() {
+	return (
+		<div className="mt-4 overflow-hidden rounded-md border border-[#1a1a1a] bg-[#0A0A0B] p-3 font-mono text-[10px] leading-relaxed">
+			<span className="text-[#34D59A]">await</span>{" "}
+			<span className="text-[#C9CBCF]">sefaz.</span>
+			<span className="text-[#F7B983]">authorize</span>
+			<span className="text-[#94979E]">(</span>
+			<span className="text-[#C9CBCF]">nfce</span>
+			<span className="text-[#94979E]">)</span>
+			<br />
+			<span className="text-[#64676F]">// status: 100 - Autorizada</span>
+		</div>
+	);
+}
+
+function MiniChart() {
+	return (
+		<div className="mt-4 flex items-end gap-1.5">
+			{[35, 55, 40, 70, 50, 80, 65].map((h, i) => (
+				<div
+					key={i}
+					className="w-full rounded-sm bg-[#2C6D4C]/30 transition-all duration-300 hover:bg-[#34D59A]/50"
+					style={{ height: `${h}%`, maxHeight: "48px", minHeight: `${h * 0.48}px` }}
+				/>
+			))}
+		</div>
+	);
+}
+
+function BentoCard({
+	children,
+	className = "",
+	onMouseMove,
+}: {
+	children: ReactNode;
+	className?: string;
+	onMouseMove?: (e: React.MouseEvent) => void;
+}) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	function handleMouseMove(e: React.MouseEvent) {
+		if (!ref.current) return;
+		const rect = ref.current.getBoundingClientRect();
+		const x = ((e.clientX - rect.left) / rect.width) * 100;
+		const y = ((e.clientY - rect.top) / rect.height) * 100;
+		ref.current.style.setProperty("--mouse-x", `${x}%`);
+		ref.current.style.setProperty("--mouse-y", `${y}%`);
+	}
+
+	return (
+		<div
+			ref={ref}
+			onMouseMove={handleMouseMove}
+			className={`bento-card group relative overflow-hidden rounded-2xl p-6 ${className}`}
+		>
+			<div
+				className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+				style={{
+					background:
+						"radial-gradient(400px circle at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(52,213,154,0.06), transparent 40%)",
+				}}
+			/>
+			<div className="relative z-10 flex h-full flex-col justify-between">
+				{children}
+			</div>
+		</div>
+	);
+}
+
+export default function Features() {
+	const t = useTranslations("features");
+
+	return (
+		<section id="features" className="relative py-32 lg:py-44">
+			<div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#2C6D4C]/30 to-transparent" />
+
+			<div className="mx-auto max-w-6xl px-6">
+				<p className="mb-4 text-[13px] font-medium uppercase tracking-[0.2em] text-[#2C6D4C]">
+					Features
+				</p>
+				<h2 className="max-w-2xl text-[28px] font-normal leading-[1.15] tracking-tighter text-[#94979E] md:text-[36px] lg:text-[48px]">
+					{t.rich("title", {
+						accent: (chunks: ReactNode) => (
+							<strong className="font-normal text-white">{chunks}</strong>
+						),
+					})}
+				</h2>
+
+				<div className="mt-14 grid grid-cols-1 gap-4 md:grid-cols-4">
+					{features.map(({ key, icon: Icon, span, visual }) => (
+						<BentoCard key={key} className={span}>
+							<div>
+								<Icon
+									size={22}
+									strokeWidth={1.5}
+									className="text-[#34D59A] transition-transform duration-500 group-hover:scale-110"
+								/>
+								<h3 className="mt-3 font-medium text-[15px] text-white/90 tracking-tight">
+									{t(`${key}.name`)}
+								</h3>
+								<p className="mt-1.5 text-[13px] leading-relaxed text-[#64676F]">
+									{t(`${key}.description`)}
+								</p>
+							</div>
+							{visual === "terminal" && <MiniTerminal />}
+							{visual === "code" && <MiniCode />}
+							{visual === "chart" && <MiniChart />}
+						</BentoCard>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/getting-started.tsx
+++ b/apps/www/src/components/sections/getting-started.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+export default function GettingStarted() {
+	const t = useTranslations("getStarted");
+	const [copied, setCopied] = useState(false);
+
+	const steps = [
+		{ comment: t("step1Comment"), command: t("step1") },
+		{ comment: t("step2Comment"), command: t("step2") },
+		{ comment: t("step3Comment"), command: t("step3") },
+	];
+
+	function handleCopy() {
+		const commands = steps.map((s) => s.command).join("\n");
+		navigator.clipboard.writeText(commands);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	}
+
+	return (
+		<section className="relative py-28 lg:py-36">
+			<div className="mx-auto max-w-3xl px-6">
+				<p className="mb-4 text-[13px] font-medium uppercase tracking-[0.2em] text-[#2C6D4C]">
+					Quick Start
+				</p>
+				<h2 className="max-w-lg text-[24px] font-normal leading-[1.15] tracking-tighter text-[#94979E] md:text-[28px] lg:text-[40px]">
+					{t.rich("title", {
+						accent: (chunks: ReactNode) => (
+							<strong className="font-normal text-white">{chunks}</strong>
+						),
+					})}
+				</h2>
+
+				{/* Terminal */}
+				<div className="group mt-12 overflow-hidden rounded-xl border border-[#1a1a1a] bg-[#0A0A0B] transition-colors duration-300 hover:border-[#2C6D4C]/30">
+					{/* Terminal header */}
+					<div className="flex items-center justify-between border-b border-[#1a1a1a] px-5 py-3.5">
+						<div className="flex items-center gap-3">
+							<div className="flex gap-1.5">
+								<span className="h-2.5 w-2.5 rounded-full bg-[#FF5F57]/80" />
+								<span className="h-2.5 w-2.5 rounded-full bg-[#FEBC2E]/80" />
+								<span className="h-2.5 w-2.5 rounded-full bg-[#28C840]/80" />
+							</div>
+							<span className="font-mono text-[11px] text-[#64676F]">terminal</span>
+						</div>
+						<button
+							type="button"
+							onClick={handleCopy}
+							className={`cursor-pointer rounded-md px-2.5 py-1 font-mono text-[11px] transition-all duration-200 ${
+								copied
+									? "bg-[#2C6D4C]/10 text-[#34D59A]"
+									: "text-[#64676F] hover:bg-white/5 hover:text-white"
+							}`}
+						>
+							{copied ? (
+								<span className="flex items-center gap-1.5">
+									<Check size={12} /> {t("copied")}
+								</span>
+							) : (
+								<span className="flex items-center gap-1.5">
+									<Copy size={12} /> {t("copyTooltip")}
+								</span>
+							)}
+						</button>
+					</div>
+
+					{/* Terminal body */}
+					<div className="p-5 font-mono text-[13px] leading-[2]">
+						{steps.map((step, i) => (
+							<div key={i} className={i > 0 ? "mt-3" : ""}>
+								<div className="text-[#4E5159]">{step.comment}</div>
+								<div className="text-[#C9CBCF]">
+									<span className="select-none text-[#34D59A]">$ </span>
+									{step.command}
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/hero.tsx
+++ b/apps/www/src/components/sections/hero.tsx
@@ -1,0 +1,117 @@
+import { Github, BookOpen } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { links } from "@/lib/links";
+
+export default async function Hero() {
+	const t = await getTranslations("hero");
+
+	return (
+		<section className="relative -mt-16 min-h-[100svh] overflow-hidden">
+			{/* ── Perspective grid floor ── */}
+			<div className="pointer-events-none absolute inset-x-0 bottom-0 h-[60vh]">
+				<div className="perspective-grid h-full w-full" />
+			</div>
+
+			{/* ── Large gradient orb ── */}
+			<div
+				className="pointer-events-none absolute left-1/2 top-[30%] h-[600px] w-[800px] -translate-x-1/2 -translate-y-1/2 animate-glow-pulse rounded-full opacity-60 blur-[120px]"
+				style={{
+					background:
+						"radial-gradient(circle, rgba(52,213,154,0.2) 0%, rgba(44,109,76,0.1) 40%, transparent 70%)",
+				}}
+			/>
+
+			{/* ── Horizon glow line ── */}
+			<div className="glow-line pointer-events-none absolute bottom-[40%] left-0 right-0 opacity-40" />
+
+			{/* ── Floating code snippet (left) ── */}
+			<div
+				className="pointer-events-none absolute left-[8%] top-[35%] hidden rotate-[-4deg] rounded-lg border border-[#1a1a1a] bg-[#0A0A0B]/90 px-4 py-3 font-mono text-[11px] leading-relaxed opacity-30 backdrop-blur xl:block"
+				style={{ animation: "float 6s ease-in-out infinite" }}
+			>
+				<span className="text-[#34D59A]">const</span>{" "}
+				<span className="text-[#C9CBCF]">db</span>{" "}
+				<span className="text-[#94979E]">=</span>{" "}
+				<span className="text-[#34D59A]">drizzle</span>
+				<span className="text-[#94979E]">(</span>
+				<span className="text-[#F7B983]">pglite</span>
+				<span className="text-[#94979E]">);</span>
+			</div>
+
+			{/* ── Floating code snippet (right) ── */}
+			<div
+				className="pointer-events-none absolute right-[8%] top-[45%] hidden rotate-[3deg] rounded-lg border border-[#1a1a1a] bg-[#0A0A0B]/90 px-4 py-3 font-mono text-[11px] leading-relaxed opacity-25 backdrop-blur xl:block"
+				style={{ animation: "float 7s ease-in-out infinite 1s" }}
+			>
+				<span className="text-[#94979E]">{"// NFC-e emission"}</span>
+				<br />
+				<span className="text-[#34D59A]">await</span>{" "}
+				<span className="text-[#C9CBCF]">sefaz</span>
+				<span className="text-[#94979E]">.</span>
+				<span className="text-[#F7B983]">emit</span>
+				<span className="text-[#94979E]">(</span>
+				<span className="text-[#C9CBCF]">invoice</span>
+				<span className="text-[#94979E]">);</span>
+			</div>
+
+			{/* ── Content ── */}
+			<div className="relative z-10 flex min-h-[100svh] flex-col items-center justify-center px-6">
+				{/* Badge */}
+				<div
+					className="mb-10 animate-fade-in inline-flex items-center gap-2 rounded-full border border-[#2C6D4C]/40 bg-[#2C6D4C]/5 px-4 py-1.5 text-[13px] tracking-wide"
+				>
+					<span className="inline-block h-1.5 w-1.5 rounded-full bg-[#34D59A] shadow-[0_0_6px_rgba(52,213,154,0.8)]" />
+					<span className="text-[#34D59A]/90">Open Source POS System</span>
+				</div>
+
+				{/* Headline */}
+				<h1
+					className="animate-fade-in-up max-w-[900px] text-balance text-center font-display font-medium text-[clamp(2.5rem,8vw,5.5rem)] leading-[1.05] tracking-[-0.03em]"
+					style={{ animationDelay: "100ms" }}
+				>
+					{t("title")}{" "}
+					<span className="gradient-text">{t("titleAccent")}</span>
+				</h1>
+
+				{/* Subtitle */}
+				<p
+					className="mt-8 max-w-lg animate-fade-in-up text-center text-[17px] leading-[1.7] text-[#7a7d84]"
+					style={{ animationDelay: "200ms" }}
+				>
+					{t("subtitle")}
+				</p>
+
+				{/* CTAs */}
+				<div
+					className="mt-10 flex animate-fade-in-up flex-col gap-3 sm:flex-row sm:gap-4"
+					style={{ animationDelay: "300ms" }}
+				>
+					<a
+						href={links.github}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="btn-shimmer group inline-flex items-center justify-center gap-2.5 rounded-lg bg-[#2C6D4C] px-7 py-3.5 text-[15px] font-medium text-white transition-all duration-300 hover:bg-[#34D59A] hover:shadow-[0_0_40px_rgba(52,213,154,0.3)]"
+					>
+						<Github size={17} className="transition-transform duration-300 group-hover:scale-110" />
+						{t("cta")}
+					</a>
+					<a
+						href={links.docs}
+						className="inline-flex items-center justify-center gap-2.5 rounded-lg border border-[#222] bg-transparent px-7 py-3.5 text-[15px] font-medium text-[#94979E] transition-all duration-300 hover:border-[#2C6D4C]/50 hover:text-white"
+					>
+						<BookOpen size={17} />
+						{t("ctaSecondary")}
+					</a>
+				</div>
+
+				{/* Scroll line */}
+				<div
+					className="absolute bottom-12 left-1/2 -translate-x-1/2 animate-fade-in"
+					style={{ animationDelay: "600ms" }}
+				>
+					<div className="h-12 w-px bg-gradient-to-b from-transparent via-[#2C6D4C]/50 to-transparent" />
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/problem.tsx
+++ b/apps/www/src/components/sections/problem.tsx
@@ -1,0 +1,36 @@
+import { getTranslations } from "next-intl/server";
+
+export default async function Problem() {
+	const t = await getTranslations("problem");
+
+	return (
+		<section className="relative py-32 lg:py-44">
+			{/* Left accent line */}
+			<div className="absolute bottom-0 left-[10%] top-0 hidden w-px bg-gradient-to-b from-transparent via-[#2C6D4C]/20 to-transparent lg:block" />
+
+			<div className="mx-auto max-w-6xl px-6">
+				{/* Big number + text layout */}
+				<div className="grid grid-cols-1 gap-12 lg:grid-cols-[200px_1fr] lg:gap-16">
+					{/* Large stat */}
+					<div className="flex flex-col">
+						<span className="font-display text-[80px] font-light leading-none tracking-tighter text-[#2C6D4C] lg:text-[120px]">
+							20M
+						</span>
+						<span className="mt-2 text-[13px] font-medium uppercase tracking-[0.15em] text-[#4E5159]">
+							{t("count")}
+						</span>
+					</div>
+
+					{/* Storytelling text */}
+					<p className="text-[24px] font-normal leading-[1.4] tracking-tighter text-[#94979E] md:text-[32px] lg:text-[40px]">
+						{t.rich("text", {
+							highlight: (chunks) => (
+								<strong className="font-normal text-white">{chunks}</strong>
+							),
+						})}
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/social-proof.tsx
+++ b/apps/www/src/components/sections/social-proof.tsx
@@ -1,0 +1,69 @@
+import { getTranslations } from "next-intl/server";
+import { getContributors, getGitHubStats } from "../../lib/github";
+
+export default async function SocialProof() {
+	const t = await getTranslations("socialProof");
+	const [stats, contributors] = await Promise.all([
+		getGitHubStats(),
+		getContributors(),
+	]);
+
+	const statItems = [
+		{ value: stats.stars, label: t("stars") },
+		{ value: stats.contributors, label: t("contributors") },
+		{ value: stats.forks, label: t("commits") },
+	].filter((s) => s.value > 0);
+
+	if (statItems.length === 0 && contributors.length === 0) return null;
+
+	return (
+		<section className="relative py-28 lg:py-36">
+			<div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#1a1a1a] to-transparent" />
+
+			<div className="mx-auto max-w-5xl px-6">
+				{statItems.length > 0 && (
+					<div className="grid grid-cols-3 gap-8 border-b border-[#1a1a1a] pb-12">
+						{statItems.map((stat) => (
+							<div key={stat.label}>
+								<span className="block font-display text-[clamp(2rem,5vw,4rem)] font-light tracking-tight text-white">
+									{stat.value}
+								</span>
+								<span className="mt-1 block text-[12px] font-medium uppercase tracking-[0.15em] text-[#64676F]">
+									{stat.label}
+								</span>
+							</div>
+						))}
+					</div>
+				)}
+
+				{contributors.length > 0 && (
+					<div className="mt-12 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+						<p className="max-w-sm text-[15px] leading-relaxed text-[#64676F]">
+							{t("joinMessage", { count: String(stats.contributors) })}
+						</p>
+						<div className="flex -space-x-3">
+							{contributors.map((c) => (
+								<a
+									key={c.login}
+									href={c.profileUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									title={c.login}
+									className="relative transition-transform duration-200 hover:z-10 hover:scale-110"
+								>
+									<img
+										src={c.avatarUrl}
+										alt={c.login}
+										width={36}
+										height={36}
+										className="h-9 w-9 rounded-full border-2 border-[#0C0D0D] grayscale transition-all duration-200 hover:grayscale-0"
+									/>
+								</a>
+							))}
+						</div>
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/components/sections/tech-stack.tsx
+++ b/apps/www/src/components/sections/tech-stack.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { getTranslations } from "next-intl/server";
+
+const techs = [
+	{ key: "pglite", color: "#34D59A" },
+	{ key: "nextjs", color: "#ffffff" },
+	{ key: "drizzle", color: "#37C38F" },
+	{ key: "tailwind", color: "#34D59A" },
+	{ key: "trpc", color: "#2C6D4C" },
+	{ key: "betterAuth", color: "#37C38F" },
+] as const;
+
+export default async function TechStack() {
+	const t = await getTranslations("techStack");
+
+	return (
+		<section className="relative overflow-hidden py-28 lg:py-36">
+			{/* Top edge glow */}
+			<div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#2C6D4C]/20 to-transparent" />
+
+			<div className="mx-auto max-w-6xl px-6">
+				<p className="mb-4 text-[13px] font-medium uppercase tracking-[0.2em] text-[#2C6D4C]">
+					Tech Stack
+				</p>
+				<h2 className="max-w-2xl indent-0 text-[24px] font-normal leading-[1.15] tracking-tighter text-[#94979E] md:text-[32px] lg:indent-20 lg:text-[44px]">
+					{t.rich("title", {
+						accent: (chunks: ReactNode) => (
+							<strong className="font-normal text-white">
+								{chunks}
+							</strong>
+						),
+					})}
+				</h2>
+
+				{/* Tech list — editorial */}
+				<div className="mt-16 space-y-0 divide-y divide-[#1a1a1a]">
+					{techs.map((tech, i) => (
+						<div
+							key={tech.key}
+							className="group grid grid-cols-1 items-baseline gap-4 py-6 transition-colors duration-300 md:grid-cols-[120px_1fr_2fr] md:gap-8 md:py-8"
+						>
+							<span className="font-mono text-[12px] uppercase tracking-widest text-[#2C6D4C]/40">
+								0{i + 1}
+							</span>
+							<h3 className="text-[20px] font-medium tracking-tight text-white/90 transition-colors group-hover:text-[#34D59A] md:text-[22px]">
+								{t(`${tech.key}.name`)}
+							</h3>
+							<p className="text-[15px] leading-[1.7] text-[#64676F]">
+								{t(`${tech.key}.description`)}
+							</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/www/src/i18n/config.ts
+++ b/apps/www/src/i18n/config.ts
@@ -1,0 +1,3 @@
+export const locales = ["en", "pt-BR"] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = "en";

--- a/apps/www/src/i18n/locale.ts
+++ b/apps/www/src/i18n/locale.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { type Locale, locales, defaultLocale } from "./config";
+
+export async function setLocale(locale: Locale) {
+	const cookieStore = await cookies();
+	cookieStore.set("locale", locale, {
+		path: "/",
+		maxAge: 60 * 60 * 24 * 365,
+		sameSite: "lax",
+	});
+}
+
+export async function getLocale(): Promise<Locale> {
+	const cookieStore = await cookies();
+	const value = cookieStore.get("locale")?.value;
+	if (value && locales.includes(value as Locale)) return value as Locale;
+	return defaultLocale;
+}

--- a/apps/www/src/i18n/request.ts
+++ b/apps/www/src/i18n/request.ts
@@ -1,0 +1,24 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+import { defaultLocale, type Locale, locales } from "./config";
+
+const messageImports = {
+	en: () => import("../messages/en"),
+	"pt-BR": () => import("../messages/pt-BR"),
+} as const;
+
+export default getRequestConfig(async () => {
+	const cookieStore = await cookies();
+	const cookieLocale = cookieStore.get("locale")?.value;
+	const locale: Locale =
+		cookieLocale && locales.includes(cookieLocale as Locale)
+			? (cookieLocale as Locale)
+			: defaultLocale;
+
+	const messages = (await messageImports[locale]()).default;
+
+	return {
+		locale,
+		messages,
+	};
+});

--- a/apps/www/src/lib/github.ts
+++ b/apps/www/src/lib/github.ts
@@ -1,0 +1,73 @@
+const REPO = "JoaoHenriqueBarbosa/FinOpenPOS";
+
+export interface GitHubStats {
+	stars: number;
+	contributors: number;
+	forks: number;
+	license: string;
+}
+
+export interface Contributor {
+	login: string;
+	avatarUrl: string;
+	profileUrl: string;
+	contributions: number;
+}
+
+export async function getGitHubStats(): Promise<GitHubStats> {
+	try {
+		const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+			next: { revalidate: 3600 },
+			headers: { Accept: "application/vnd.github.v3+json" },
+		});
+		if (!res.ok) return { stars: 0, contributors: 0, forks: 0, license: "MIT" };
+		const data = await res.json();
+
+		// Get contributor count
+		const contribRes = await fetch(
+			`https://api.github.com/repos/${REPO}/contributors?per_page=1&anon=true`,
+			{
+				next: { revalidate: 3600 },
+				headers: { Accept: "application/vnd.github.v3+json" },
+			},
+		);
+		// Parse contributor count from Link header
+		let contributorCount = 1;
+		const linkHeader = contribRes.headers.get("Link");
+		if (linkHeader) {
+			const match = linkHeader.match(/page=(\d+)>; rel="last"/);
+			if (match) contributorCount = Number.parseInt(match[1], 10);
+		}
+
+		return {
+			stars: data.stargazers_count ?? 0,
+			contributors: contributorCount,
+			forks: data.forks_count ?? 0,
+			license: data.license?.spdx_id ?? "MIT",
+		};
+	} catch {
+		return { stars: 0, contributors: 0, forks: 0, license: "MIT" };
+	}
+}
+
+export async function getContributors(): Promise<Contributor[]> {
+	try {
+		const res = await fetch(
+			`https://api.github.com/repos/${REPO}/contributors?per_page=12`,
+			{
+				next: { revalidate: 3600 },
+				headers: { Accept: "application/vnd.github.v3+json" },
+			},
+		);
+		if (!res.ok) return [];
+		const data = await res.json();
+		return data.map((c: Record<string, unknown>) => ({
+			login: c.login,
+			avatarUrl: c.avatar_url,
+			profileUrl: c.html_url,
+			contributions: c.contributions,
+		}));
+	} catch {
+		return [];
+	}
+}

--- a/apps/www/src/lib/links.ts
+++ b/apps/www/src/lib/links.ts
@@ -1,0 +1,8 @@
+import { env } from "@finopenpos/env/web";
+
+export const links = {
+	github: "https://github.com/JoaoHenriqueBarbosa/FinOpenPOS",
+	docs: env.NEXT_PUBLIC_DOCS_URL,
+	apiDocs: env.NEXT_PUBLIC_API_DOCS_URL,
+	license: "https://github.com/JoaoHenriqueBarbosa/FinOpenPOS/blob/main/LICENSE",
+} as const;

--- a/apps/www/src/messages/en.ts
+++ b/apps/www/src/messages/en.ts
@@ -1,0 +1,132 @@
+const messages = {
+	common: {
+		locale: "English",
+		switchLocale: "Português",
+	},
+	header: {
+		features: "Features",
+		docs: "Documentation",
+		apiDocs: "API",
+		github: "GitHub",
+		getStarted: "Get Started",
+	},
+	hero: {
+		title: "The open-source POS",
+		titleAccent: "Brazil deserves",
+		subtitle:
+			"A complete point-of-sale system with fiscal integration, built by developers, for everyone. Free, transparent, and community-driven.",
+		cta: "View on GitHub",
+		ctaSecondary: "Read the Docs",
+	},
+	problem: {
+		text: "Most can't afford expensive POS systems with fiscal compliance. The few open-source alternatives are outdated, poorly maintained, and lack <highlight>real NF-e and NFC-e integration</highlight>. We're changing that.",
+		count: "small businesses in Brazil",
+	},
+	techStack: {
+		title: "Built with the <accent>best tools</accent> for the job",
+		pglite: {
+			name: "PGLite",
+			description:
+				"Full PostgreSQL in the browser via WASM. No server needed. Your data stays with you.",
+		},
+		nextjs: {
+			name: "Next.js 16",
+			description:
+				"The latest React framework with Server Components, Turbopack, and the new proxy architecture.",
+		},
+		drizzle: {
+			name: "Drizzle ORM",
+			description:
+				"Type-safe SQL that feels like writing queries. Zero overhead, maximum developer experience.",
+		},
+		tailwind: {
+			name: "Tailwind CSS 4",
+			description:
+				"Utility-first CSS rebuilt from the ground up. Lightning-fast, incredibly powerful.",
+		},
+		trpc: {
+			name: "tRPC",
+			description:
+				"End-to-end type-safe APIs. No code generation, no schemas to maintain.",
+		},
+		betterAuth: {
+			name: "Better Auth",
+			description:
+				"Modern authentication that just works. Email/password, sessions, and more.",
+		},
+	},
+	features: {
+		title: "Everything you need to <accent>run a business</accent>",
+		pos: {
+			name: "Point of Sale",
+			description:
+				"Fast, intuitive checkout. Works offline with PGLite. Supports multiple payment methods.",
+		},
+		fiscal: {
+			name: "Fiscal Integration",
+			description:
+				"Complete NF-e and NFC-e support. SEFAZ communication, digital certificates, DANFE generation.",
+		},
+		multiTenant: {
+			name: "Multi-Tenancy",
+			description:
+				"One installation, multiple businesses. Each with isolated data and configurations.",
+		},
+		offline: {
+			name: "Offline-First",
+			description:
+				"Powered by PGLite — full PostgreSQL in the browser. No server dependency for daily operations.",
+		},
+		dashboard: {
+			name: "Analytics Dashboard",
+			description:
+				"Sales reports, revenue charts, customer insights. All in real-time with beautiful visualizations.",
+		},
+		i18n: {
+			name: "Internationalization",
+			description:
+				"Built-in support for multiple languages. Currently English and Portuguese (Brazil).",
+		},
+	},
+	socialProof: {
+		stars: "Stars",
+		contributors: "Contributors",
+		commits: "Commits",
+		license: "License",
+		joinMessage:
+			"Join {count} developers building the future of POS in Brazil",
+	},
+	getStarted: {
+		title: "Up and running in <accent>under a minute</accent>",
+		step1Comment: "# Clone the repository",
+		step1: "git clone https://github.com/JoaoHenriqueBarbosa/FinOpenPOS.git",
+		step2Comment: "# Install dependencies",
+		step2: "cd FinOpenPOS && bun install",
+		step3Comment: "# Start development server",
+		step3: "bun run dev",
+		copyTooltip: "Copy to clipboard",
+		copied: "Copied!",
+	},
+	cta: {
+		title: "Ready to contribute?",
+		subtitle:
+			"FinOpenPOS is open-source and community-driven. Every contribution counts.",
+		starOnGithub: "Star on GitHub",
+		readDocs: "Read the Docs",
+	},
+	footer: {
+		builtWith: "Built with",
+		by: "by the FinOpenPOS community",
+		github: "GitHub",
+		docs: "Documentation",
+		license: "MIT License",
+	},
+} as const;
+
+export default messages;
+
+type DeepStringify<T> = {
+	[K in keyof T]: T[K] extends string ? string : DeepStringify<T[K]>;
+};
+
+export type Messages = DeepStringify<typeof messages>;

--- a/apps/www/src/messages/pt-BR.ts
+++ b/apps/www/src/messages/pt-BR.ts
@@ -1,0 +1,132 @@
+const messages = {
+	common: {
+		locale: "Português",
+		switchLocale: "English",
+	},
+	header: {
+		features: "Funcionalidades",
+		docs: "Documentação",
+		apiDocs: "API",
+		github: "GitHub",
+		getStarted: "Começar",
+	},
+	hero: {
+		title: "O PDV open-source que o",
+		titleAccent: "Brasil merece",
+		subtitle:
+			"Um sistema completo de ponto de venda com integração fiscal, construído por desenvolvedores, para todos. Gratuito, transparente e movido pela comunidade.",
+		cta: "Ver no GitHub",
+		ctaSecondary: "Ler a Documentação",
+	},
+	problem: {
+		text: "A maioria não pode pagar por sistemas de PDV caros com conformidade fiscal. As poucas alternativas open-source são desatualizadas, mal mantidas e não têm <highlight>integração real com NF-e e NFC-e</highlight>. Estamos mudando isso.",
+		count: "pequenas empresas no Brasil",
+	},
+	techStack: {
+		title: "Construído com as <accent>melhores ferramentas</accent> para o trabalho",
+		pglite: {
+			name: "PGLite",
+			description:
+				"PostgreSQL completo no navegador via WASM. Sem necessidade de servidor. Seus dados ficam com você.",
+		},
+		nextjs: {
+			name: "Next.js 16",
+			description:
+				"O mais recente framework React com Server Components, Turbopack e a nova arquitetura de proxy.",
+		},
+		drizzle: {
+			name: "Drizzle ORM",
+			description:
+				"SQL type-safe que parece escrever queries. Zero overhead, máxima experiência do desenvolvedor.",
+		},
+		tailwind: {
+			name: "Tailwind CSS 4",
+			description:
+				"CSS utility-first reconstruído do zero. Extremamente rápido, incrivelmente poderoso.",
+		},
+		trpc: {
+			name: "tRPC",
+			description:
+				"APIs type-safe de ponta a ponta. Sem geração de código, sem schemas para manter.",
+		},
+		betterAuth: {
+			name: "Better Auth",
+			description:
+				"Autenticação moderna que simplesmente funciona. Email/senha, sessões e muito mais.",
+		},
+	},
+	features: {
+		title: "Tudo que você precisa para <accent>gerenciar um negócio</accent>",
+		pos: {
+			name: "Ponto de Venda",
+			description:
+				"Checkout rápido e intuitivo. Funciona offline com PGLite. Suporta múltiplos métodos de pagamento.",
+		},
+		fiscal: {
+			name: "Integração Fiscal",
+			description:
+				"Suporte completo a NF-e e NFC-e. Comunicação SEFAZ, certificados digitais, geração de DANFE.",
+		},
+		multiTenant: {
+			name: "Multi-Tenancy",
+			description:
+				"Uma instalação, múltiplos negócios. Cada um com dados e configurações isolados.",
+		},
+		offline: {
+			name: "Offline-First",
+			description:
+				"Alimentado por PGLite — PostgreSQL completo no navegador. Sem dependência de servidor para operações diárias.",
+		},
+		dashboard: {
+			name: "Painel Analítico",
+			description:
+				"Relatórios de vendas, gráficos de receita, insights de clientes. Tudo em tempo real com visualizações bonitas.",
+		},
+		i18n: {
+			name: "Internacionalização",
+			description:
+				"Suporte integrado para múltiplos idiomas. Atualmente Inglês e Português (Brasil).",
+		},
+	},
+	socialProof: {
+		stars: "Estrelas",
+		contributors: "Contribuidores",
+		commits: "Commits",
+		license: "Licença",
+		joinMessage:
+			"Junte-se a {count} desenvolvedores construindo o futuro do PDV no Brasil",
+	},
+	getStarted: {
+		title: "Funcionando em <accent>menos de um minuto</accent>",
+		step1Comment: "# Clone o repositório",
+		step1: "git clone https://github.com/JoaoHenriqueBarbosa/FinOpenPOS.git",
+		step2Comment: "# Instale as dependências",
+		step2: "cd FinOpenPOS && bun install",
+		step3Comment: "# Inicie o servidor de desenvolvimento",
+		step3: "bun run dev",
+		copyTooltip: "Copiar para área de transferência",
+		copied: "Copiado!",
+	},
+	cta: {
+		title: "Pronto para contribuir?",
+		subtitle:
+			"FinOpenPOS é open-source e movido pela comunidade. Cada contribuição conta.",
+		starOnGithub: "Estrelar no GitHub",
+		readDocs: "Ler a Documentação",
+	},
+	footer: {
+		builtWith: "Construído com",
+		by: "pela comunidade FinOpenPOS",
+		github: "GitHub",
+		docs: "Documentação",
+		license: "Licença MIT",
+	},
+} as const;
+
+export default messages;
+
+type DeepStringify<T> = {
+	[K in keyof T]: T[K] extends string ? string : DeepStringify<T[K]>;
+};
+
+export type Messages = DeepStringify<typeof messages>;

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,0 +1,28 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"baseUrl": ".",
+		"plugins": [{ "name": "next" }],
+		"paths": { "@/*": ["./src/*"] }
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
+	"exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,28 @@
         "typescript": "^5",
       },
     },
+    "apps/www": {
+      "name": "@finopenpos/www",
+      "version": "0.1.0",
+      "dependencies": {
+        "@finopenpos/env": "workspace:*",
+        "@finopenpos/ui": "workspace:*",
+        "lucide-react": "catalog:",
+        "next": "catalog:",
+        "next-intl": "^4.8.3",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+      },
+      "devDependencies": {
+        "@finopenpos/config": "workspace:*",
+        "@tailwindcss/postcss": "^4.2.1",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "postcss": "^8.5.6",
+        "tailwindcss": "catalog:",
+        "typescript": "^5",
+      },
+    },
     "packages/api": {
       "name": "@finopenpos/api",
       "version": "0.0.0",
@@ -396,6 +418,8 @@
     "@finopenpos/fiscal": ["@finopenpos/fiscal@workspace:packages/fiscal"],
 
     "@finopenpos/ui": ["@finopenpos/ui@workspace:packages/ui"],
+
+    "@finopenpos/www": ["@finopenpos/www@workspace:apps/www"],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_DOCS_URL=https://fin-open-pos.johnenrique.tech/docs
+        - NEXT_PUBLIC_API_DOCS_URL=https://fin-open-pos.johnenrique.tech/app/api/docs
+    ports:
+      - "80:80"
+    environment:
+      - NODE_ENV=production
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-dev-secret-key-change-in-production}
+      - BETTER_AUTH_URL=https://fin-open-pos.johnenrique.tech/app
+      - LANDING_URL=https://fin-open-pos.johnenrique.tech
+      - NEXT_PUBLIC_DOCS_URL=https://fin-open-pos.johnenrique.tech/docs
+      - NEXT_PUBLIC_API_DOCS_URL=https://fin-open-pos.johnenrique.tech/app/api/docs
+    restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 # Start web app (with db setup)
 cd /app/apps/web
+mkdir -p data
 bun scripts/ensure-db.ts && bunx drizzle-kit push
 BASE_PATH=/app bun next start --port 3001 &
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Start web app (with db setup)
+cd /app/apps/web
+bun scripts/ensure-db.ts && bunx drizzle-kit push
+BASE_PATH=/app bun next start --port 3001 &
+
+# Start www (landing page)
+cd /app/apps/www
+bun next start --port 3003 &
+
+# Start docs
+cd /app/apps/docs
+BASE_PATH=/docs bun next start --port 3002 &
+
+# Start nginx in foreground
+nginx -g 'daemon off;'

--- a/docs/plans/2026-03-09-landing-page-design.md
+++ b/docs/plans/2026-03-09-landing-page-design.md
@@ -1,0 +1,531 @@
+# Landing Page Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create `apps/www` — a developer-focused landing page with Neon.com-inspired dark aesthetic, serving as the public face of FinOpenPOS.
+
+**Architecture:** New Next.js app in the monorepo (`@finopenpos/www`, port 3003). SSR with Server Components for Lighthouse 100. CSS-only animations. i18n via next-intl (cookie-based). `apps/web` redirects unauthenticated `/` to `LANDING_URL`. Non-production Dockerfile serves all 3 apps via Nginx reverse proxy.
+
+**Tech Stack:** Next.js 16, Tailwind CSS 4, next-intl, lucide-react, @finopenpos/ui, CSS animations
+
+---
+
+### Task 1: Scaffold apps/www
+
+**Files:**
+- Create: `apps/www/package.json`
+- Create: `apps/www/tsconfig.json`
+- Create: `apps/www/next.config.ts`
+- Create: `apps/www/postcss.config.mjs`
+- Create: `apps/www/src/app/layout.tsx` (minimal, just renders children)
+- Create: `apps/www/src/app/page.tsx` (placeholder "Hello")
+
+**Step 1: Create package.json**
+
+```json
+{
+  "name": "@finopenpos/www",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbo --port 3003",
+    "build": "next build",
+    "start": "next start --port 3003"
+  },
+  "dependencies": {
+    "@finopenpos/ui": "workspace:*",
+    "lucide-react": "catalog:",
+    "next": "catalog:",
+    "next-intl": "^4.8.3",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@finopenpos/config": "workspace:*",
+    "@tailwindcss/postcss": "^4.2.1",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "postcss": "^8.5.6",
+    "tailwindcss": "catalog:",
+    "typescript": "^5"
+  }
+}
+```
+
+**Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "baseUrl": ".",
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+**Step 3: Create next.config.ts**
+
+```typescript
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+
+const nextConfig = {};
+
+export default withNextIntl(nextConfig);
+```
+
+**Step 4: Create postcss.config.mjs**
+
+```javascript
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;
+```
+
+**Step 5: Create minimal layout + page**
+
+`apps/www/src/app/layout.tsx`:
+```tsx
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "FinOpenPOS",
+  description: "Open-source point of sale system",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+`apps/www/src/app/page.tsx`:
+```tsx
+export default function Home() {
+  return <div>FinOpenPOS Landing</div>;
+}
+```
+
+**Step 6: Update monorepo config**
+
+Add to root `package.json` scripts:
+```json
+"dev:www": "turbo -F @finopenpos/www dev"
+```
+
+**Step 7: Run `bun install` and verify dev server starts**
+
+```bash
+bun install
+bun run dev:www
+```
+Expected: App runs on http://localhost:3003
+
+**Step 8: Commit**
+
+```
+feat(www): scaffold landing page app
+```
+
+---
+
+### Task 2: Neon-Inspired Design System (globals.css)
+
+**Files:**
+- Create: `apps/www/src/app/globals.css`
+- Modify: `apps/www/src/app/layout.tsx` (import css, add font, dark class)
+
+**Step 1: Create globals.css with Neon color palette**
+
+Neon design tokens (extracted from neon.com):
+- Backgrounds: `#0C0D0D`, `#0A0A0B`, `#111215`, `#151617`
+- Light sections: `#E4F1EB`, `#EBF5F0`, `#F6FDFA`, `#CAE6D9`
+- Green primary: `#2C6D4C`, accent: `#34D59A`, dark: `#285D49`, mid: `#37C38F`
+- Grays: 12-step scale from near-black to near-white
+- Text: `#C9CBCF`, `#94979E`, `#A3A6B3`, `#C2C4CC`, white
+- Shadows dark: `0px 8px 20px 0px rgba(0,0,0,.4)`
+- Glow gradient: `linear-gradient(90deg, rgba(57,165,125,0.6) ...)`
+- Blur: `backdrop-blur-[15px]`
+- Border radius: `rounded-sm` (0.125rem) default
+- Typography: `font-medium`/`font-normal`, headings 28-80px, `tracking-tighter`, `leading-dense`
+
+Create CSS with custom properties, Tailwind theme extensions, glow keyframes, and utility classes for the Neon aesthetic.
+
+**Step 2: Update layout.tsx**
+
+- Import globals.css
+- Add Inter font via `next/font/google` with `display: "swap"`
+- Force dark mode with `className="dark"` on `<html>`
+- Set `bg-[#0C0D0D] text-white antialiased` on body
+
+**Step 3: Verify visually**
+
+Run dev server, confirm dark background renders correctly.
+
+**Step 4: Commit**
+
+```
+feat(www): add neon-inspired design system
+```
+
+---
+
+### Task 3: i18n Setup
+
+**Files:**
+- Create: `apps/www/src/i18n/config.ts`
+- Create: `apps/www/src/i18n/request.ts`
+- Create: `apps/www/src/i18n/locale.ts`
+- Create: `apps/www/src/messages/en.ts`
+- Create: `apps/www/src/messages/pt-BR.ts`
+- Modify: `apps/www/src/app/layout.tsx` (add NextIntlClientProvider)
+
+**Step 1: Create i18n config files**
+
+Copy pattern from `apps/web/src/i18n/` — same cookie-based approach, same locales.
+
+**Step 2: Create message files**
+
+Landing page sections: `hero`, `problem`, `techStack`, `features`, `getStarted`, `cta`, `footer`, `common` (locale switcher labels).
+
+**Step 3: Wire up layout.tsx with NextIntlClientProvider**
+
+**Step 4: Verify i18n works**
+
+Set cookie `locale=pt-BR`, confirm text changes.
+
+**Step 5: Commit**
+
+```
+feat(www): add i18n with next-intl
+```
+
+---
+
+### Task 4: Header/Nav Component
+
+**Files:**
+- Create: `apps/www/src/components/header.tsx`
+- Create: `apps/www/src/components/locale-switcher.tsx`
+- Modify: `apps/www/src/app/layout.tsx` (add Header)
+
+**Step 1: Build Header**
+
+- Sticky header with backdrop-blur, border-bottom
+- Logo (FinOpenPOS text or icon)
+- Nav links: Features, Docs, GitHub
+- Locale switcher (en/pt-BR)
+- CTA button: "Get Started" / "Star on GitHub"
+- Mobile: hamburger menu
+- Style: `bg-[#0C0D0D]/80 backdrop-blur-[15px] border-b border-[#1a1a1a]`
+
+**Step 2: Build LocaleSwitcher**
+
+Dropdown or toggle, sets cookie, triggers page refresh.
+
+**Step 3: Commit**
+
+```
+feat(www): add header with nav and locale switcher
+```
+
+---
+
+### Task 5: Hero Section
+
+**Files:**
+- Create: `apps/www/src/components/sections/hero.tsx`
+- Modify: `apps/www/src/app/page.tsx` (add Hero)
+
+**Step 1: Build Hero**
+
+- Full-viewport height section
+- Bold headline: problem statement (e.g., "The open-source POS Brazil deserves")
+- Subheadline: brief description
+- Two CTAs: "View on GitHub" (primary green), "Read the Docs" (outline)
+- Background: radial gradient glow effect (green) + subtle grid/dot pattern via CSS
+- CSS animation: gentle pulse on the glow, fade-in on text
+- Responsive: 60px heading → 28px on mobile (matching Neon's scale)
+
+**Step 2: Commit**
+
+```
+feat(www): add hero section
+```
+
+---
+
+### Task 6: Problem/Solution Section
+
+**Files:**
+- Create: `apps/www/src/components/sections/problem.tsx`
+- Modify: `apps/www/src/app/page.tsx`
+
+**Step 1: Build Problem/Solution**
+
+- Dark section with green accent text for key phrases
+- Storytelling approach: "Brazil has X million small businesses... no open-source POS exists..."
+- Show don't tell: contrast "before" (expensive/closed) vs "after" (free/open)
+- Typography: large indent style (like Neon h2: `indent-24 text-[48px]`)
+- `<strong>` tags in white, rest in `gray-new-50` (#94979E)
+
+**Step 2: Commit**
+
+```
+feat(www): add problem/solution section
+```
+
+---
+
+### Task 7: Tech Stack Section
+
+**Files:**
+- Create: `apps/www/src/components/sections/tech-stack.tsx`
+- Modify: `apps/www/src/app/page.tsx`
+
+**Step 1: Build Tech Stack**
+
+- Light green background section (`#E4F1EB`) for visual contrast
+- Grid of tech cards: PGLite, Next.js 16, Drizzle ORM, Tailwind CSS 4, tRPC, Better Auth
+- Each card: icon/logo, name, one-line description of WHY it was chosen (not what it is)
+- Cards: `border border-[#CAE6D9] bg-white/60 backdrop-blur-[15px] rounded-sm shadow`
+- Text color: `text-[#0C0D0D]` (dark on light bg)
+
+**Step 2: Commit**
+
+```
+feat(www): add tech stack section
+```
+
+---
+
+### Task 8: Features Section
+
+**Files:**
+- Create: `apps/www/src/components/sections/features.tsx`
+- Modify: `apps/www/src/app/page.tsx`
+
+**Step 1: Build Features**
+
+- Dark section
+- Key features: POS, Fiscal (NF-e/NFC-e), Multi-tenancy, Offline-first (PGLite), Dashboard/Analytics, i18n
+- Each feature: icon (lucide-react), title, description
+- Layout: 2-3 column grid, responsive
+- Subtle green glow on hover (CSS transition)
+- Style: cards with `border-[#1a1a1a] bg-[#111215]`
+
+**Step 2: Commit**
+
+```
+feat(www): add features section
+```
+
+---
+
+### Task 9: Social Proof Section (GitHub Stats)
+
+**Files:**
+- Create: `apps/www/src/components/sections/social-proof.tsx`
+- Create: `apps/www/src/lib/github.ts` (fetch stars/contributors)
+- Modify: `apps/www/src/app/page.tsx`
+
+**Step 1: Create GitHub data fetcher**
+
+Server-side fetch with `revalidate: 3600` (1h cache):
+- Stars count
+- Contributors count
+- Latest release/tag
+- Open issues count
+
+Use GitHub REST API (no auth needed for public repos).
+
+**Step 2: Build Social Proof section**
+
+- Stats row: stars, contributors, commits, license badge
+- Animated counting numbers (CSS counter or server-rendered)
+- "Join X developers building the future of POS in Brazil"
+- Contributor avatars grid (top contributors from API)
+
+**Step 3: Commit**
+
+```
+feat(www): add social proof section with live github stats
+```
+
+---
+
+### Task 10: Getting Started Section
+
+**Files:**
+- Create: `apps/www/src/components/sections/getting-started.tsx`
+- Modify: `apps/www/src/app/page.tsx`
+
+**Step 1: Build Getting Started**
+
+- Terminal-style code block with copy button
+- Steps: clone, install, dev
+- Syntax highlighting via CSS (green for commands, gray for comments)
+- Dark card with `bg-[#0A0A0B] border border-[#1a1a1a] rounded-sm`
+- Monospace font for code
+
+**Step 2: Commit**
+
+```
+feat(www): add getting started section
+```
+
+---
+
+### Task 11: CTA + Footer
+
+**Files:**
+- Create: `apps/www/src/components/sections/cta.tsx`
+- Create: `apps/www/src/components/footer.tsx`
+- Modify: `apps/www/src/app/page.tsx`
+- Modify: `apps/www/src/app/layout.tsx` (add Footer)
+
+**Step 1: Build CTA**
+
+- Full-width section with `bg-[#151617]`
+- Large heading (80px → 32px responsive): "Ready to contribute?"
+- Two buttons: "Star on GitHub", "Read the Docs"
+- Subtle green gradient glow behind the heading
+
+**Step 2: Build Footer**
+
+- Links: GitHub, Docs, License (MIT)
+- "Built with" tech badges
+- Border top `border-[#1a1a1a]`
+
+**Step 3: Commit**
+
+```
+feat(www): add cta and footer
+```
+
+---
+
+### Task 12: LANDING_URL Redirect in apps/web
+
+**Files:**
+- Modify: `packages/env/src/server.ts` (add LANDING_URL)
+- Modify: `apps/web/src/proxy.ts` (redirect `/` to LANDING_URL)
+- Modify: `apps/web/src/app/page.tsx` (add redirect as fallback)
+
+**Step 1: Add LANDING_URL to env**
+
+In `packages/env/src/server.ts`, add:
+```typescript
+LANDING_URL: z.string().url().optional(),
+```
+
+**Step 2: Update proxy.ts**
+
+When path is exactly `/` and `LANDING_URL` is set and user is not authenticated → redirect to `LANDING_URL`.
+
+```typescript
+import { env } from "@finopenpos/env/server";
+
+// At the top of the proxy function, before the auth check:
+if (pathname === "/" && env.LANDING_URL) {
+  return NextResponse.redirect(env.LANDING_URL);
+}
+```
+
+**Step 3: Update page.tsx as fallback**
+
+```tsx
+import { redirect } from "next/navigation";
+import { env } from "@finopenpos/env/server";
+
+export default function Home() {
+  if (env.LANDING_URL) {
+    redirect(env.LANDING_URL);
+  }
+  redirect("/login");
+}
+```
+
+**Step 4: Commit**
+
+```
+feat(web): redirect root to LANDING_URL
+```
+
+---
+
+### Task 13: Update Dockerfile (non-production)
+
+**Files:**
+- Modify: `Dockerfile`
+
+**Step 1: Update Dockerfile**
+
+- `deps` stage: add `apps/www/package.json` and `apps/docs/package.json` COPY
+- `build` stage: run `turbo build` (builds all 3 apps)
+- `runtime` stage: copy all 3 `.next` builds + node_modules
+- Add Nginx config: `/` → www:3003, `/app` → web:3001, `/docs` → docs:3002
+- Create: `nginx.conf`
+- Create: `docker-entrypoint.sh` — starts 3 `next start` processes + nginx
+- Install nginx in runtime stage
+
+**Step 2: Commit**
+
+```
+feat(docker): add www and docs to non-production dockerfile
+```
+
+---
+
+### Task 14: Final Polish & Verification
+
+**Step 1: Run `bun run build` from root**
+
+Verify all 3 apps build successfully.
+
+**Step 2: Run Lighthouse audit**
+
+```bash
+npx lighthouse http://localhost:3003 --only-categories=performance,accessibility,best-practices,seo
+```
+
+Target: 100/100/100/100
+
+**Step 3: Test i18n**
+
+Verify both en and pt-BR render correctly.
+
+**Step 4: Test responsive**
+
+Check mobile, tablet, desktop breakpoints.
+
+**Step 5: Final commit**
+
+```
+feat(www): polish and verify landing page
+```

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,55 @@
+upstream www {
+    server 127.0.0.1:3003;
+}
+
+upstream web {
+    server 127.0.0.1:3001;
+}
+
+upstream docs {
+    server 127.0.0.1:3002;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    # Web app (basePath=/app)
+    location /app {
+        proxy_pass http://web;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Documentation (basePath=/docs)
+    location /docs {
+        proxy_pass http://docs;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Landing page (default, no basePath)
+    location / {
+        proxy_pass http://www;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check-types": "turbo check-types",
     "dev:web": "turbo -F web dev",
     "dev:docs": "turbo -F docs dev",
+		"dev:www": "turbo -F @finopenpos/www dev",
     "db:push": "turbo -F @finopenpos/db db:push",
     "db:studio": "turbo -F @finopenpos/db db:studio",
     "db:generate": "turbo -F @finopenpos/db db:generate",

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -9,6 +9,7 @@ export const env = createEnv({
     BETTER_AUTH_URL: z.string().url().default("http://localhost:3001"),
     CORS_ORIGIN: z.string().url().optional(),
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    LANDING_URL: z.string().url().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -2,7 +2,13 @@ import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
 export const env = createEnv({
-  client: {},
-  runtimeEnv: {},
+  client: {
+    NEXT_PUBLIC_DOCS_URL: z.string().url().default("http://localhost:3002"),
+    NEXT_PUBLIC_API_DOCS_URL: z.string().url().default("http://localhost:3001/api/docs"),
+  },
+  runtimeEnv: {
+    NEXT_PUBLIC_DOCS_URL: process.env.NEXT_PUBLIC_DOCS_URL,
+    NEXT_PUBLIC_API_DOCS_URL: process.env.NEXT_PUBLIC_API_DOCS_URL,
+  },
   emptyStringAsUndefined: true,
 });


### PR DESCRIPTION
## Summary
- New `apps/www` Next.js app — developer-focused landing page with Neon.com-inspired dark aesthetic
- Nginx reverse proxy serving 3 apps: `/` (landing), `/app` (web), `/docs` (fumadocs)
- docker-compose.yml configured for Coolify deployment at `fin-open-pos.johnenrique.tech`
- `LANDING_URL`, `NEXT_PUBLIC_DOCS_URL`, `NEXT_PUBLIC_API_DOCS_URL` env vars (zero hardcoded URLs)
- `basePath` support via `BASE_PATH` env var for web (`/app`) and docs (`/docs`)
- `/api/docs` and `/api/openapi.json` made public (no auth required)
- i18n (en + pt-BR) with next-intl, cookie-based

## Test plan
- [ ] `bun run dev:www` starts landing page on port 3003
- [ ] All sections render: hero, problem, tech stack, features, social proof, getting started, CTA
- [ ] Locale switcher toggles between EN and PT-BR
- [ ] GitHub stats load (stars, contributors, forks)
- [ ] `docker compose up --build` serves all 3 apps via Nginx
- [ ] `/app` routes to web app, `/docs` routes to fumadocs
- [ ] `/app/api/docs` shows Scalar API reference without auth
- [ ] Links use env vars, not hardcoded URLs