### PR TITLE
feat(www): add landing page app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,5 +82,5 @@ COPY nginx.conf /etc/nginx/http.d/default.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-EXPOSE 80
+EXPOSE 3111
 CMD ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         - NEXT_PUBLIC_DOCS_URL=https://fin-open-pos.johnenrique.tech/docs
         - NEXT_PUBLIC_API_DOCS_URL=https://fin-open-pos.johnenrique.tech/app/api/docs
     ports:
-      - "80:80"
+      - "3111:3111"
     environment:
       - NODE_ENV=production
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-dev-secret-key-change-in-production}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Start nginx first (so port 80 responds immediately)
+nginx
+
 # Start web app (with db setup)
 cd /app/apps/web
 mkdir -p data
@@ -15,5 +18,5 @@ bun next start --port 3003 &
 cd /app/apps/docs
 BASE_PATH=/docs bun next start --port 3002 &
 
-# Start nginx in foreground
-nginx -g 'daemon off;'
+# Wait for any process to exit
+wait

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ upstream docs {
 }
 
 server {
-    listen 80;
+    listen 3111;
     server_name _;
 
     # Web app (basePath=/app)


### PR DESCRIPTION
## Summary
- New `apps/www` Next.js app — developer-focused landing page with Neon.com-inspired dark aesthetic
- Nginx reverse proxy serving 3 apps on port 3111: `/` (landing), `/app` (web), `/docs` (fumadocs)
- docker-compose.yml configured for Coolify deployment at `fin-open-pos.johnenrique.tech`
- `LANDING_URL`, `NEXT_PUBLIC_DOCS_URL`, `NEXT_PUBLIC_API_DOCS_URL` env vars (zero hardcoded URLs)
- `basePath` support via `BASE_PATH` env var for web (`/app`) and docs (`/docs`)
- `/api/docs` and `/api/openapi.json` made public (no auth required)
- i18n (en + pt-BR) with next-intl, cookie-based

## Test plan
- [ ] `bun run dev:www` starts landing page on port 3003
- [ ] All sections render: hero, problem, tech stack, features, social proof, getting started, CTA
- [ ] Locale switcher toggles between EN and PT-BR
- [ ] GitHub stats load (stars, contributors, forks)
- [ ] `docker compose up --build` serves all 3 apps via Nginx on port 3111
- [ ] `/app` routes to web app, `/docs` routes to fumadocs
- [ ] `/app/api/docs` shows Scalar API reference without auth
- [ ] Links use env vars, not hardcoded URLs