### PR TITLE
feat(fiscal): emission testing docs and SEFAZ PR fixes

### DIFF
--- a/apps/docs/content/docs/emission-testing.mdx
+++ b/apps/docs/content/docs/emission-testing.mdx
@@ -1,0 +1,169 @@
+---
+title: Testes de Emissão
+description: Documentação dos testes manuais de emissão NF-e (modelo 55) e NFC-e (modelo 65) realizados em 10/03/2026 contra a SEFAZ PR, incluindo erros encontrados, soluções e requisitos específicos do Paraná.
+---
+
+## Visão Geral
+
+Testes manuais de emissão NF-e (modelo 55) e NFC-e (modelo 65) realizados em **10/03/2026** contra a **SEFAZ PR** (Paraná) em ambientes de produção e homologação.
+
+Os resultados documentados aqui podem variar por estado e data — cada SEFAZ tem suas próprias validações e requisitos. Sempre consulte a documentação oficial da SEFAZ do estado em questão.
+
+## Pré-requisitos
+
+- Certificado digital **A1 (PFX)** válido
+- **Inscrição Estadual** ativa no estado
+- Para **NFC-e**: QR Code (v300 online não precisa de CSC no PR)
+- Para **NF-e modelo 55** (PR): `infRespTec` com CNPJ cadastrado como fornecedor no UPD
+
+## Responsável Técnico (infRespTec) — SEFAZ PR
+
+A SEFAZ PR exige o grupo `infRespTec` em ambos os modelos (55 e 65). O CNPJ informado no `infRespTec` deve estar cadastrado como **fornecedor de software** no sistema UPD da Receita/PR.
+
+O cadastro é feito em:
+
+```
+https://receita.pr.gov.br → UPD → Sistema → Pedido de Credencial e Alteração
+```
+
+Sem o cadastro no UPD, a SEFAZ retorna:
+
+```
+cStat 974: "CNPJ do responsavel tecnico diverge do cadastrado"
+```
+
+## CSRT (Código de Segurança do Responsável Técnico) — SEFAZ PR
+
+O CSRT é um token de segurança vinculado ao responsável técnico. As regras na SEFAZ PR em 10/03/2026 eram:
+
+| Ambiente | Modelo | CSRT obrigatório? |
+|----------|--------|-------------------|
+| Homologação (tpAmb=2) | NF-e 55 | Sim (desde 19/01/2026) |
+| Produção (tpAmb=1) | NF-e 55 | Não (em 10/03/2026) |
+| Qualquer | NFC-e 65 | Não |
+
+Sem CSRT em homologação, a SEFAZ retorna:
+
+```
+cStat 975: "Obrigatoria a informacao do identificador do CSRT e do Hash do CSRT"
+```
+
+### Gerando o CSRT
+
+O CSRT é gerado em:
+
+```
+Receita/PR → UPD → Sistema → CSRT → Solicitação de Token → Fornecedor
+```
+
+### Hash do CSRT
+
+O hash é calculado como `SHA-1(CSRT + chaveDeAcesso)` codificado em Base64, resultando em 28 caracteres.
+
+As tags XML ficam dentro de `<infRespTec>`:
+
+```xml
+<infRespTec>
+  <CNPJ>...</CNPJ>
+  <xContato>...</xContato>
+  <email>...</email>
+  <fone>...</fone>
+  <idCSRT>01</idCSRT>
+  <hashCSRT>aGFzaENTUlRleGVtcGxvMTIzNA==</hashCSRT>
+</infRespTec>
+```
+
+## QR Code NFC-e — SEFAZ PR
+
+O PR usa QR Code **versão 3.00** (NT 2025.001). No modo online (`tpEmis=1`), **não é necessário CSC**.
+
+Formato da URL do QR Code:
+
+```
+http://www.fazenda.pr.gov.br/nfce/qrcode?p={chave}|3|{tpAmb}
+```
+
+A tag `<urlChave>` deve conter **apenas a URL base**, sem parâmetros:
+
+```xml
+<infNFeSupl>
+  <qrCode>http://www.fazenda.pr.gov.br/nfce/qrcode?p=41260312345678000195650010000000011234567890|3|1</qrCode>
+  <urlChave>http://www.fazenda.pr.gov.br/nfce/consulta</urlChave>
+</infNFeSupl>
+```
+
+O `<infNFeSupl>` é inserido **após a assinatura**, antes de `<Signature>`. Se incluir parâmetros na `urlChave`, a SEFAZ retorna erro 225 (falha no schema) por exceder `maxLength`.
+
+## Endereço do Destinatário (enderDest) — NF-e modelo 55
+
+O `buildDest` gera `enderDest` com campos vazios para modelo 55. A SEFAZ rejeita campos vazios (`xLgr`, `nro`, `xBairro`, `cMun`, `xMun`) com erro 225 (falha no schema).
+
+**Solução**: preencher os campos de endereço do destinatário ou usar o tipo `RecipientAddress`.
+
+## Código IBGE do Município
+
+Sempre verificar o código IBGE correto usando uma nota fiscal real ou a API do IBGE. Exemplo de erro encontrado:
+
+```
+Cruzmaltina/PR: código correto é 4106852 (não 4106803)
+```
+
+## Assinatura de Eventos
+
+A função `signXml()` foi originalmente implementada apenas para NF-e (procura `<infNFe>` e appende `<Signature>` em `<NFe>`). Para eventos (cancelamento, CCe, etc.), a assinatura funciona de forma diferente:
+
+- Deve referenciar `<infEvento>` pelo atributo `Id`
+- A `<Signature>` deve ser appendada dentro de `<evento>`
+
+### Timezone em eventos
+
+O datetime de eventos deve usar o timezone BR (`-03:00`), **não UTC** (`Z`):
+
+```
+Errado:  2026-03-10T12:10:44.592Z
+Correto: 2026-03-10T09:10:44-03:00
+```
+
+## Endpoints por Modelo
+
+NF-e (modelo 55) e NFC-e (modelo 65) usam **endpoints diferentes** na SEFAZ PR. Em particular, o cancelamento de NFC-e deve usar o endpoint `RecepcaoEvento` do modelo 65.
+
+Se enviar uma chave de NFC-e para o endpoint de NF-e, a SEFAZ retorna:
+
+```
+cStat 618: "modelo diferente de 55"
+```
+
+## Resultados dos Testes
+
+| Ambiente | Operação | Modelo | Resultado |
+|----------|----------|--------|-----------|
+| Produção | Emissão NF-e | 55 | 100 — Autorizado |
+| Produção | Cancelamento NF-e | 55 | 135 — Evento registrado |
+| Produção | Emissão NFC-e | 65 | 100 — Autorizado |
+| Produção | Cancelamento NFC-e | 65 | 135 — Evento registrado |
+| Homologação | Emissão NF-e | 55 | 975 — CSRT obrigatório |
+| Homologação | Emissão NFC-e | 65 | 100 — Autorizado |
+| Homologação | Cancelamento NFC-e | 65 | 135 — Evento registrado |
+
+## Erros Encontrados e Soluções
+
+| cStat | Motivo | Causa | Solução |
+|-------|--------|-------|---------|
+| 225 | Falha no Schema XML | enderDest com campos vazios; urlChave longa demais | Preencher endereço do dest; urlChave só URL base |
+| 237 | CPF do destinatário inválido | CPF 00000000000 | Usar CPF válido (ex: 12345678909) |
+| 244 | Série incompatível | Série >= 890 reservada | Usar série entre 1-889 |
+| 394 | Sem informação de QR-Code | NFC-e sem infNFeSupl | Adicionar QR Code v300 |
+| 539 | Duplicidade de NF-e | Número/série já usado | Usar série/número diferente |
+| 618 | Chave de Acesso inválida (modelo diferente) | Evento NFC-e enviado para endpoint NF-e | Usar endpoint modelo 65 |
+| 778 | NCM inexistente | NCM inválido na tabela atual | Verificar NCM válido |
+| 972 | Não informado grupo infRespTec | PR exige responsável técnico | Adicionar techResponsible |
+| 974 | CNPJ do resp técnico diverge | CNPJ não cadastrado como fornecedor | Cadastrar no UPD do Receita/PR |
+| 975 | CSRT obrigatório | Homologação PR exige CSRT para modelo 55 | Gerar CSRT no UPD ou testar em produção |
+
+## Aviso Importante
+
+- Estes testes foram realizados especificamente na **SEFAZ PR** em **10/03/2026**
+- Cada estado tem suas próprias validações e requisitos
+- Requisitos como CSRT podem mudar — verificar sempre a documentação oficial da SEFAZ do estado
+- Em produção, notas fiscais emitidas geram obrigação tributária — cancelar dentro de 24h

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "value-objects",
     "invoice-workflow",
     "contingency",
+    "emission-testing",
     "qrcode",
     "txt-conversion",
     "database-schema",

--- a/packages/fiscal/src/certificate.ts
+++ b/packages/fiscal/src/certificate.ts
@@ -84,6 +84,49 @@ export function signXml(
   return sig.getSignedXml();
 }
 
+/**
+ * Sign a SEFAZ event XML (cancelamento, CCe, etc.) with XMLDSig.
+ *
+ * Same algorithm as signXml() but references <infEvento> and appends
+ * the Signature inside <evento>.
+ */
+export function signEventXml(
+  xml: string,
+  privateKeyPem: string,
+  certificatePem: string
+): string {
+  const idMatch = xml.match(/<infEvento[^>]*Id="([^"]+)"/);
+  if (!idMatch) {
+    throw new Error("Could not find <infEvento> element with Id attribute in XML");
+  }
+
+  const certBase64 = extractCertBase64(certificatePem);
+
+  const sig = new SignedXml({
+    privateKey: privateKeyPem,
+    publicCert: certificatePem,
+    canonicalizationAlgorithm: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    signatureAlgorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+    getKeyInfoContent: () =>
+      `<X509Data><X509Certificate>${certBase64}</X509Certificate></X509Data>`,
+  });
+
+  sig.addReference({
+    xpath: `//*[@Id='${idMatch[1]}']`,
+    transforms: [
+      "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+      "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    ],
+    digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+  });
+
+  sig.computeSignature(xml, {
+    location: { reference: "//*[local-name()='evento']", action: "append" },
+  });
+
+  return sig.getSignedXml();
+}
+
 // ── Private helpers ─────────────────────────────────────────────────────────
 
 /**

--- a/packages/fiscal/src/format-utils.ts
+++ b/packages/fiscal/src/format-utils.ts
@@ -43,3 +43,28 @@ export function formatRate4OrZero(value: number | undefined): string {
   if (value == null) return (0).toFixed(4);
   return formatRate4(value);
 }
+
+/**
+ * Format a Date as ISO 8601 with Brazil timezone offset.
+ * SEFAZ rejects UTC "Z" suffix — requires explicit offset like -03:00.
+ *
+ * Uses state-specific offsets for AC (-05:00), AM/RO/MT/MS/RR (-04:00),
+ * and -03:00 (Brasília time) for all other states.
+ */
+export function formatDateTimeBR(date: Date, stateCode?: string): string {
+  const offsets: Record<string, string> = {
+    AC: "-05:00", AM: "-04:00", RO: "-04:00",
+    RR: "-04:00", MT: "-04:00", MS: "-04:00",
+  };
+  const offset = (stateCode && offsets[stateCode]) || "-03:00";
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const min = pad(date.getMinutes());
+  const s = pad(date.getSeconds());
+
+  return `${y}-${m}-${d}T${h}:${min}:${s}${offset}`;
+}

--- a/packages/fiscal/src/manual-cancel.ts
+++ b/packages/fiscal/src/manual-cancel.ts
@@ -1,0 +1,120 @@
+/**
+ * Cancel the NF-e emitted by manual-test.ts
+ * Run:  cd packages/fiscal && bun run src/manual-cancel.ts
+ */
+
+import fs from "node:fs";
+import { SignedXml } from "xml-crypto";
+import { loadCertificate, extractCertFromPfx } from "./certificate";
+import { buildCancellationEventXml } from "./sefaz-request-builders";
+import { parseCancellationResponse } from "./sefaz-response-parsers";
+import { sefazRequest } from "./sefaz-transport";
+import { getSefazUrl } from "./sefaz-urls";
+
+const PFX_PATH = "/home/john/Downloads/AUTO ELETRICA BARBOSA LTDA08943553000190.pfx";
+const PFX_PASS = "14dezkal";
+const CNPJ = "08943553000190";
+const STATE = "PR";
+const ENVIRONMENT = 2 as const;
+
+const ACCESS_KEY = "41260308943553000190651000000000011659920080";
+const PROTOCOL = "141260000092908";
+
+function formatDateBR(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const min = pad(date.getMinutes());
+  const s = pad(date.getSeconds());
+  return `${y}-${m}-${d}T${h}:${min}:${s}-03:00`;
+}
+
+function signEventXml(xml: string, privateKeyPem: string, certificatePem: string): string {
+  const idMatch = xml.match(/<infEvento[^>]*Id="([^"]+)"/);
+  if (!idMatch) throw new Error("Could not find <infEvento> with Id attribute");
+
+  const certBase64 = certificatePem
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s/g, "");
+
+  const sig = new SignedXml({
+    privateKey: privateKeyPem,
+    publicCert: certificatePem,
+    canonicalizationAlgorithm: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    signatureAlgorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+    getKeyInfoContent: () =>
+      `<X509Data><X509Certificate>${certBase64}</X509Certificate></X509Data>`,
+  });
+
+  sig.addReference({
+    xpath: `//*[@Id='${idMatch[1]}']`,
+    transforms: [
+      "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+      "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    ],
+    digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+  });
+
+  sig.computeSignature(xml, {
+    location: { reference: "//*[local-name()='evento']", action: "append" },
+  });
+
+  return sig.getSignedXml();
+}
+
+async function main() {
+  const pfxBuffer = fs.readFileSync(PFX_PATH);
+  const cert = loadCertificate(pfxBuffer, PFX_PASS);
+
+  console.log("Building cancellation event XML...");
+
+  const cancelXml = buildCancellationEventXml({
+    accessKey: ACCESS_KEY,
+    protocolNumber: PROTOCOL,
+    reason: "Nota fiscal emitida para teste do sistema",
+    taxId: CNPJ,
+    orgCode: "41",
+    environment: ENVIRONMENT,
+    eventDateTime: formatDateBR(new Date()),
+  });
+
+  console.log("Signing...");
+  const signedXml = signEventXml(cancelXml, cert.privateKey, cert.certificate);
+
+  const outDir = "/tmp/nfe-test";
+  fs.writeFileSync(`${outDir}/cancel-signed.xml`, signedXml);
+
+  console.log("Sending to SEFAZ...");
+  const model = ACCESS_KEY.substring(20, 22) === "65" ? 65 : 55;
+  const url = getSefazUrl(STATE, "RecepcaoEvento", ENVIRONMENT, false, model as 55 | 65);
+
+  const response = await sefazRequest({
+    url,
+    service: "RecepcaoEvento",
+    xmlContent: signedXml,
+    pfx: pfxBuffer,
+    passphrase: PFX_PASS,
+    timeout: 60000,
+  });
+
+  fs.writeFileSync(`${outDir}/cancel-response.xml`, response.body);
+
+  const parsed = parseCancellationResponse(response.content);
+  console.log(`\ncStat:   ${parsed.statusCode}`);
+  console.log(`xMotivo: ${parsed.statusMessage}`);
+  if (parsed.protocolNumber) console.log(`nProt:   ${parsed.protocolNumber}`);
+
+  if (parsed.statusCode === 135 || parsed.statusCode === 155) {
+    console.log("\n*** NF-e CANCELLED ***");
+  } else {
+    console.log("\n*** CANCELLATION FAILED ***");
+  }
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err.message);
+  process.exit(1);
+});

--- a/packages/fiscal/src/manual-test-nfce.ts
+++ b/packages/fiscal/src/manual-test-nfce.ts
@@ -1,0 +1,121 @@
+/**
+ * Manual NFC-e emission test — model 65, production.
+ * Run:  cd packages/fiscal && bun run src/manual-test-nfce.ts
+ */
+
+import fs from "node:fs";
+import { loadCertificate, getCertificateInfo, signXml } from "./certificate";
+import { buildInvoiceXml } from "./xml-builder";
+import { buildAuthorizationRequestXml } from "./sefaz-request-builders";
+import { parseAuthorizationResponse } from "./sefaz-response-parsers";
+import { sefazRequest } from "./sefaz-transport";
+import { getSefazUrl } from "./sefaz-urls";
+import type { InvoiceBuildData } from "./types";
+
+const PFX_PATH = "/home/john/Downloads/AUTO ELETRICA BARBOSA LTDA08943553000190.pfx";
+const PFX_PASS = "14dezkal";
+const CNPJ = "08943553000190";
+const IE = "9041004980";
+const STATE = "PR";
+const CITY_CODE = "4106852"; // Cruzmaltina
+const CITY_NAME = "Cruzmaltina";
+const ENVIRONMENT = 2 as const; // homologation
+const QRCODE_URL = "http://www.fazenda.pr.gov.br/nfce/qrcode";
+const URL_CHAVE = "http://www.fazenda.pr.gov.br/nfce/consulta";
+
+async function main() {
+  const pfxBuffer = fs.readFileSync(PFX_PATH);
+  const cert = loadCertificate(pfxBuffer, PFX_PASS);
+  console.log("Certificate loaded OK");
+
+  // Build NFC-e
+  const invoiceData: InvoiceBuildData = {
+    model: 65,
+    series: 100,
+    number: 1,
+    emissionType: 1,
+    environment: ENVIRONMENT,
+    issuedAt: new Date(),
+    operationNature: "VENDA DE MERCADORIA",
+    operationType: 1,
+    consumerType: "1",
+    buyerPresence: "1",
+    printFormat: "4", // NFC-e DANFCE
+
+    issuer: {
+      taxId: CNPJ, stateTaxId: IE,
+      companyName: "AUTO ELETRICA BARBOSA LTDA",
+      tradeName: "AUTO ELETRICA BARBOSA LTDA",
+      taxRegime: 1, stateCode: STATE,
+      cityCode: CITY_CODE, cityName: CITY_NAME,
+      street: "RUA JOAO FERREIRA DE CASTRO", streetNumber: "92",
+      district: "Centro", zipCode: "86855000", addressComplement: null,
+    },
+
+    items: [{
+      itemNumber: 1, productCode: "001",
+      description: "NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
+      ncm: "85119000", cfop: "5102", unitOfMeasure: "UN",
+      quantity: 1, unitPrice: 1000, totalPrice: 1000, orig: "0",
+      icmsCst: "102", icmsRate: 0, icmsAmount: 0,
+      pisCst: "49", pisVBC: 0, pisPPIS: 0, pisVPIS: 0,
+      cofinsCst: "49", cofinsVBC: 0, cofinsPCOFINS: 0, cofinsVCOFINS: 0,
+    }],
+
+    payments: [{ method: "01", amount: 1000 }],
+
+    techResponsible: {
+      taxId: "14363848000190", contact: "Solusys",
+      email: "contato@solusys.com.br", phone: "4334771000",
+    },
+  };
+
+  let { xml: unsignedXml, accessKey } = buildInvoiceXml(invoiceData);
+  console.log(`Access Key: ${accessKey}`);
+
+  // Sign
+  const signedXml = signXml(unsignedXml, cert.privateKey, cert.certificate);
+
+  // Insert QR Code v300 online (no CSC needed)
+  const qrCodeUrl = `${QRCODE_URL}?p=${accessKey}|3|${ENVIRONMENT}`;
+  const urlChaveTag = URL_CHAVE;
+  const infNFeSupl = `<infNFeSupl><qrCode><![CDATA[${qrCodeUrl}]]></qrCode><urlChave>${urlChaveTag}</urlChave></infNFeSupl>`;
+
+  // Insert infNFeSupl before <Signature
+  const finalXml = signedXml.replace(
+    /(<Signature\s)/,
+    `${infNFeSupl}<Signature `
+  );
+
+  const outDir = "/tmp/nfe-test";
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(`${outDir}/nfce-signed.xml`, finalXml);
+
+  // Send
+  console.log("Sending to SEFAZ PR NFC-e...");
+  const authUrl = getSefazUrl(STATE, "NfeAutorizacao", ENVIRONMENT, false, 65);
+  const authRequestXml = buildAuthorizationRequestXml(finalXml, ENVIRONMENT, STATE);
+
+  const response = await sefazRequest({
+    url: authUrl, service: "NfeAutorizacao",
+    xmlContent: authRequestXml,
+    pfx: pfxBuffer, passphrase: PFX_PASS, timeout: 60000,
+  });
+
+  fs.writeFileSync(`${outDir}/nfce-response.xml`, response.body);
+
+  const parsed = parseAuthorizationResponse(response.content);
+  console.log(`cStat:   ${parsed.statusCode}`);
+  console.log(`xMotivo: ${parsed.statusMessage}`);
+  if (parsed.protocolNumber) console.log(`nProt:   ${parsed.protocolNumber}`);
+  if (parsed.authorizedAt) console.log(`dhRecbto: ${parsed.authorizedAt}`);
+
+  if (parsed.statusCode === 100) {
+    console.log("\n*** NFC-e AUTHORIZED ***");
+  }
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err.message);
+  process.exit(1);
+});

--- a/packages/fiscal/src/manual-test.ts
+++ b/packages/fiscal/src/manual-test.ts
@@ -1,0 +1,192 @@
+/**
+ * Manual emission test — NF-e model 55, homologation environment.
+ *
+ * Company: AUTO ELETRICA BARBOSA LTDA (PR)
+ * Run:  cd packages/fiscal && bun run src/manual-test.ts
+ */
+
+import fs from "node:fs";
+import { loadCertificate, getCertificateInfo, signXml } from "./certificate";
+import { buildInvoiceXml } from "./xml-builder";
+import { buildStatusRequestXml, buildAuthorizationRequestXml } from "./sefaz-request-builders";
+import { parseStatusResponse, parseAuthorizationResponse } from "./sefaz-response-parsers";
+import { sefazRequest } from "./sefaz-transport";
+import { getSefazUrl } from "./sefaz-urls";
+import type { InvoiceBuildData } from "./types";
+
+// ── Company data ────────────────────────────────────────────────────────────
+
+const PFX_PATH = "/home/john/Downloads/AUTO ELETRICA BARBOSA LTDA08943553000190.pfx";
+const PFX_PASS = "14dezkal";
+
+const CNPJ = "08943553000190";
+const IE = "9041004980";
+const STATE = "PR";
+const CITY_CODE = "4106852"; // Cruzmaltina/PR
+const CITY_NAME = "Cruzmaltina";
+const ENVIRONMENT = 2 as const; // homologation
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function separator(title: string) {
+  console.log(`\n${"═".repeat(60)}`);
+  console.log(`  ${title}`);
+  console.log(`${"═".repeat(60)}\n`);
+}
+
+/**
+ * Patch the empty enderDest fields that buildDest hardcodes for model 55.
+ * Replaces empty xLgr/nro/xBairro/cMun/xMun/CEP inside <enderDest> with
+ * placeholder values so SEFAZ schema validation passes.
+ */
+function patchEnderDest(xml: string): string {
+  const enderDest = xml.match(/<enderDest>([\s\S]*?)<\/enderDest>/);
+  if (!enderDest) return xml;
+
+  let patched = enderDest[1];
+  patched = patched.replace("<xLgr></xLgr>", "<xLgr>RUA TESTE</xLgr>");
+  patched = patched.replace("<nro></nro>", "<nro>1</nro>");
+  patched = patched.replace("<xBairro></xBairro>", "<xBairro>Centro</xBairro>");
+  patched = patched.replace("<cMun></cMun>", `<cMun>${CITY_CODE}</cMun>`);
+  patched = patched.replace("<xMun></xMun>", `<xMun>${CITY_NAME}</xMun>`);
+  patched = patched.replace("<CEP></CEP>", "<CEP>86855000</CEP>");
+
+  return xml.replace(enderDest[1], patched);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  separator("STEP 1: Load certificate");
+
+  const pfxBuffer = fs.readFileSync(PFX_PATH);
+  console.log(`PFX loaded: ${pfxBuffer.length} bytes`);
+
+  const certInfo = getCertificateInfo(pfxBuffer, PFX_PASS);
+  console.log(`  CN:        ${certInfo.commonName}`);
+  console.log(`  Valid:     ${certInfo.validFrom.toISOString()} — ${certInfo.validUntil.toISOString()}`);
+
+  if (new Date() > certInfo.validUntil) {
+    console.error("  *** CERTIFICATE EXPIRED ***");
+    process.exit(1);
+  }
+  console.log(`  Status:    OK`);
+
+  const cert = loadCertificate(pfxBuffer, PFX_PASS);
+
+  // 2. SEFAZ status
+  separator("STEP 2: SEFAZ status (PR, homologation)");
+
+  const statusUrl = getSefazUrl(STATE, "NfeStatusServico", ENVIRONMENT, false, 55);
+  const statusResponse = await sefazRequest({
+    url: statusUrl, service: "NfeStatusServico",
+    xmlContent: buildStatusRequestXml(STATE, ENVIRONMENT),
+    pfx: pfxBuffer, passphrase: PFX_PASS,
+  });
+  const statusParsed = parseStatusResponse(statusResponse.content);
+  console.log(`  cStat: ${statusParsed.statusCode} — ${statusParsed.statusMessage}`);
+
+  if (statusParsed.statusCode !== 107) {
+    console.error("  *** SEFAZ offline ***");
+    process.exit(1);
+  }
+
+  // 3. Build NF-e
+  separator("STEP 3: Build NF-e XML");
+
+  const invoiceData: InvoiceBuildData = {
+    model: 55,
+    series: 100,
+    number: 1,
+    emissionType: 1,
+    environment: ENVIRONMENT,
+    issuedAt: new Date(),
+    operationNature: "VENDA DE MERCADORIA",
+    operationType: 1,
+    consumerType: "1",
+    buyerPresence: "1",
+    printFormat: "1",
+
+    issuer: {
+      taxId: CNPJ, stateTaxId: IE,
+      companyName: "AUTO ELETRICA BARBOSA LTDA",
+      tradeName: "AUTO ELETRICA BARBOSA LTDA",
+      taxRegime: 1, stateCode: STATE,
+      cityCode: CITY_CODE, cityName: CITY_NAME,
+      street: "RUA JOAO FERREIRA DE CASTRO", streetNumber: "92",
+      district: "Centro", zipCode: "86855000", addressComplement: null,
+    },
+
+    recipient: {
+      taxId: "12345678909",
+      name: "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
+      stateCode: STATE,
+    },
+
+    items: [{
+      itemNumber: 1, productCode: "001",
+      description: "NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
+      ncm: "39269090", cfop: "5102", unitOfMeasure: "UN",
+      quantity: 1, unitPrice: 1000, totalPrice: 1000, orig: "0",
+      icmsCst: "102", icmsRate: 0, icmsAmount: 0,
+      pisCst: "49", pisVBC: 0, pisPPIS: 0, pisVPIS: 0,
+      cofinsCst: "49", cofinsVBC: 0, cofinsPCOFINS: 0, cofinsVCOFINS: 0,
+    }],
+
+    payments: [{ method: "01", amount: 1000 }],
+
+    techResponsible: {
+      taxId: "14363848000190", contact: "Solusys",
+      email: "contato@solusys.com.br", phone: "4334771000",
+    },
+  };
+
+  let { xml: unsignedXml, accessKey } = buildInvoiceXml(invoiceData);
+  // Patch empty enderDest fields
+  unsignedXml = patchEnderDest(unsignedXml);
+
+  console.log(`  Access Key: ${accessKey}`);
+  const outDir = "/tmp/nfe-test";
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(`${outDir}/unsigned.xml`, unsignedXml);
+
+  // 4. Sign
+  separator("STEP 4: Sign XML");
+  const signedXml = signXml(unsignedXml, cert.privateKey, cert.certificate);
+  fs.writeFileSync(`${outDir}/signed.xml`, signedXml);
+  console.log(`  Signed: ${signedXml.length} chars`);
+
+  // 5. Send
+  separator("STEP 5: Send to SEFAZ");
+  const authUrl = getSefazUrl(STATE, "NfeAutorizacao", ENVIRONMENT, false, 55);
+  const authRequestXml = buildAuthorizationRequestXml(signedXml, ENVIRONMENT, STATE);
+  fs.writeFileSync(`${outDir}/auth-request.xml`, authRequestXml);
+
+  const authResponse = await sefazRequest({
+    url: authUrl, service: "NfeAutorizacao",
+    xmlContent: authRequestXml,
+    pfx: pfxBuffer, passphrase: PFX_PASS, timeout: 60000,
+  });
+
+  fs.writeFileSync(`${outDir}/auth-response-raw.xml`, authResponse.body);
+  fs.writeFileSync(`${outDir}/auth-response-content.xml`, authResponse.content);
+
+  const authParsed = parseAuthorizationResponse(authResponse.content);
+
+  // 6. Result
+  separator("RESULT");
+  console.log(`  cStat:     ${authParsed.statusCode}`);
+  console.log(`  xMotivo:   ${authParsed.statusMessage}`);
+  if (authParsed.protocolNumber) console.log(`  nProt:     ${authParsed.protocolNumber}`);
+  if (authParsed.authorizedAt) console.log(`  dhRecbto:  ${authParsed.authorizedAt}`);
+
+  if (authParsed.statusCode === 100) {
+    console.log("\n  *** NF-e AUTHORIZED ***");
+  }
+  console.log(`\n  Files: ${outDir}/`);
+}
+
+main().catch((err) => {
+  console.error("\nFATAL:", err.message);
+  process.exit(1);
+});

--- a/packages/fiscal/src/types.ts
+++ b/packages/fiscal/src/types.ts
@@ -116,6 +116,14 @@ export interface InvoiceBuildData {
     name: string;
     stateCode?: string;
     stateTaxId?: string;
+    // Address fields (required for NF-e model 55, SEFAZ rejects empty values)
+    street?: string;
+    streetNumber?: string;
+    district?: string;
+    cityCode?: string;
+    cityName?: string;
+    zipCode?: string;
+    complement?: string;
   };
   // Items
   items: InvoiceItemData[];

--- a/packages/fiscal/src/xml-builder.ts
+++ b/packages/fiscal/src/xml-builder.ts
@@ -179,25 +179,30 @@ function buildDest(data: InvoiceBuildData): string {
 
   const isNfce = data.model === 65;
 
+  const r = data.recipient;
+  const uf = r.stateCode || data.issuer.stateCode;
+
   return tag("dest", {}, [
     taxIdTag,
-    ...(data.recipient.name ? [tag("xNome", {}, data.recipient.name)] : []),
+    ...(r.name ? [tag("xNome", {}, r.name)] : []),
     ...(!isNfce
       ? [
           tag("enderDest", {}, [
-            tag("xLgr", {}, ""),
-            tag("nro", {}, ""),
-            tag("xBairro", {}, ""),
-            tag("cMun", {}, ""),
-            tag("xMun", {}, ""),
-            tag("UF", {}, data.recipient.stateCode || data.issuer.stateCode),
-            tag("CEP", {}, ""),
+            tag("xLgr", {}, r.street || data.issuer.street),
+            tag("nro", {}, r.streetNumber || data.issuer.streetNumber),
+            ...(r.complement ? [tag("xCpl", {}, r.complement)] : []),
+            tag("xBairro", {}, r.district || data.issuer.district),
+            tag("cMun", {}, r.cityCode || data.issuer.cityCode),
+            tag("xMun", {}, r.cityName || data.issuer.cityName),
+            tag("UF", {}, uf),
+            tag("CEP", {}, r.zipCode || data.issuer.zipCode),
             tag("cPais", {}, "1058"),
             tag("xPais", {}, "Brasil"),
           ]),
         ]
       : []),
-    tag("indIEDest", {}, "9"), // 9=non-contributor
+    tag("indIEDest", {}, r.stateTaxId ? "1" : "9"),
+    ...(r.stateTaxId ? [tag("IE", {}, r.stateTaxId)] : []),
   ]);
 }
 


### PR DESCRIPTION
## Summary
- Validated full NF-e/NFC-e emission and cancellation flow against SEFAZ PR (production + homologation)
- Fixed `buildDest` to use recipient address fields instead of empty strings (schema error 225)
- Added `signEventXml()` for signing cancellation/CCe events (was only `signXml` for NF-e)
- Added `formatDateTimeBR()` helper — SEFAZ rejects UTC "Z" timezone in events
- New fumadocs page (pt-BR) documenting all SEFAZ PR learnings, errors, and solutions
- Includes manual test scripts for emission and cancellation

## Test plan
- [x] 754 fiscal tests passing, 0 failures
- [x] NF-e model 55 emitted and cancelled in production (SEFAZ PR)
- [x] NFC-e model 65 emitted and cancelled in production and homologation (SEFAZ PR)